### PR TITLE
Wait for browser switch result before clearing the request

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
@@ -34,6 +34,14 @@ public class BrowserSwitchActivity extends Activity {
         return sReturnUri;
     }
 
+    public static boolean isBrowserSwitchComplete() {
+        return getReturnUri() != Uri.EMPTY;
+    }
+
+    public static void prepareForBrowserSwitch() {
+        sReturnUri = Uri.EMPTY;
+    }
+
     /**
      * Clears the return uri.
      */

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -61,7 +61,7 @@ public abstract class BrowserSwitchFragment extends Fragment {
     public void onResume() {
         super.onResume();
 
-        if (isBrowserSwitching()) {
+        if (isBrowserSwitching() && BrowserSwitchActivity.isBrowserSwitchComplete()) {
             Uri returnUri = BrowserSwitchActivity.getReturnUri();
 
             int requestCode = mRequestCode;
@@ -132,6 +132,8 @@ public abstract class BrowserSwitchFragment extends Fragment {
             onBrowserSwitchResult(requestCode, result, null);
             return;
         }
+
+        BrowserSwitchActivity.prepareForBrowserSwitch();
 
         mRequestCode = requestCode;
         mContext.startActivity(intent);

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchActivityTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchActivityTest.java
@@ -10,6 +10,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.util.ActivityController;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
@@ -70,6 +71,35 @@ public class BrowserSwitchActivityTest {
         BrowserSwitchActivity.clearReturnUri();
 
         assertNull(BrowserSwitchActivity.getReturnUri());
+    }
+
+    @Test
+    public void prepareForBrowserSwitch_setsReturnUriAsEmptyUri() {
+        BrowserSwitchActivity.prepareForBrowserSwitch();
+
+        assertEquals(Uri.EMPTY, BrowserSwitchActivity.getReturnUri());
+    }
+
+    @Test
+    public void isBrowserSwitchComplete_whenAwaitingResponse_returnsFalse() {
+        BrowserSwitchActivity.prepareForBrowserSwitch();
+
+        assertFalse(BrowserSwitchActivity.isBrowserSwitchComplete());
+    }
+
+    @Test
+    public void isBrowserSwitchComplete_whenBrowserSwitchResponse_returnsTrue() {
+        setup("http://example.com?key=value");
+
+        assertTrue(BrowserSwitchActivity.isBrowserSwitchComplete());
+    }
+
+    @Test
+    public void isBrowserSwitchComplete_whenEmptyBrowserSwitchResponse_returnsTrue() {
+        mActivityController = Robolectric.buildActivity(BrowserSwitchActivity.class, new Intent());
+        mActivity = mActivityController.setup().get();
+
+        assertTrue(BrowserSwitchActivity.isBrowserSwitchComplete());
     }
 
     private void setup(String url) {

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
@@ -140,6 +140,30 @@ public class BrowserSwitchFragmentTest {
     }
 
     @Test
+    public void onResume_doesNotCallOnBrowserSwitchResultUntilComplete() {
+        mockContext(mock(Context.class));
+        mFragment.browserSwitch(42, "http://example.com/");
+
+        mFragment.onResume();
+
+        assertEquals(42, mFragment.mRequestCode);
+        assertFalse(mFragment.onBrowserSwitchResultCalled);
+    }
+
+    @Test
+    public void onResume_callsOnBrowserSwitchResultWhenComplete() {
+        mockContext(mock(Context.class));
+        mFragment.browserSwitch(42, "http://example.com/");
+        handleBrowserSwitchResponse(42, "http://example.com/?key=value");
+
+        mFragment.onResume();
+
+        assertTrue(mFragment.onBrowserSwitchResultCalled);
+        assertEquals(Integer.MIN_VALUE, mFragment.mRequestCode);
+        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.OK, mFragment.result);
+    }
+
+    @Test
     public void onSaveInstanceState_savesStateWhenNotBrowserSwitching() {
         Bundle bundle = new Bundle();
         mFragment.onSaveInstanceState(bundle);


### PR DESCRIPTION
Firefox for Android with Tab Queue enabled backgrounds URL requests.

This pattern breaks Browser Switch:

- Browser Switch starts, the user decides to use Firefox Tab Queue to open the URL.
- Tab Queue backgrounds the new URL request, finishes, and Android foregrounds the caller app.
- BrowserSwitchFragment is resumed, and assumes the Browser Switch is complete.
- BrowserSwitchFragment get the incorrect result from BrowserSwitchActivity and clears the request.

The solution is for BrowserSwitchActivity to enter a new state, waiting for a Browser Switch response.
BraintreeSwitchFragment waits for BrowserSwitchActivity to prepare the proper response before
accepting the response, and clearing the request.