### PR TITLE
Prevent Chrome Custom Tab from being killed when user leaves

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/ChromeCustomTabs.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/ChromeCustomTabs.java
@@ -57,10 +57,7 @@ public class ChromeCustomTabs {
             Bundle extras = new Bundle();
             extras.putBinder("android.support.customtabs.extra.SESSION", null);
             intent.putExtras(extras);
-            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK |
-                    Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS |
-                    Intent.FLAG_ACTIVITY_NO_HISTORY |
-                    Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         }
 
         return intent;


### PR DESCRIPTION
If you switch to a password manager or try to use something like 1Password's password keyboard, the Chrome Custom Tab is killed as a result of the Intent flags specified and the user has to start the flow over from the beginning.

This opts to leave the Chrome Custom Tab around rather than break or degrade flows for password managers or multitasking. This does make it possible for the user to revisit the Chrome Custom Tab after they've finished their browser switch and switch back to the app again causing a weird switch back where nothing happens. This odd behavior can be mitigated by the page that returns the user to the app by displaying a page that says everything is complete and removing the button/link that switches back to the app.