### PR TITLE
Move to support fragments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-26.0.0
-    - android-26
+    - build-tools-27.0.3
+    - android-27
 script: ./gradlew --info clean lint test

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -16,12 +16,8 @@ android {
 }
 
 dependencies {
-    // Require the minimum major version.
-    // browser-switch consumers are recommended to use the latest minor/patch version
-    // noinspection GradleDependency
-    implementation 'com.android.support:support-fragment:27.+'
-    // noinspection GradleDependency
-    implementation 'com.android.support:support-annotations:27.+'
+    implementation 'com.android.support:support-fragment:27.0.0'
+    implementation 'com.android.support:support-annotations:27.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.9'

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -4,23 +4,28 @@ apply plugin: 'signing'
 apply plugin: 'io.codearte.nexus-staging'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 6
         versionName '0.1.5'
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:26.0.0'
+    // Require the minimum major version.
+    // browser-switch consumers are recommended to use the latest minor/patch version
+    // noinspection GradleDependency
+    implementation 'com.android.support:support-fragment:27.+'
+    // noinspection GradleDependency
+    implementation 'com.android.support:support-annotations:27.+'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.2.22'
-    testCompile 'org.robolectric:robolectric:3.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'org.robolectric:robolectric:3.8'
 }
 
 task javadocs(type: Javadoc) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitch.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitch.java
@@ -1,0 +1,61 @@
+package com.braintreepayments.browserswitch;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+
+import java.util.List;
+
+class BrowserSwitch {
+    Intent getIntentFromUrl(Context context, String url) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        ChromeCustomTabs.addChromeCustomTabsExtras(context, intent);
+
+        return intent;
+    }
+
+    BrowserSwitchResult verifyBrowserSwitch(Context context, int requestCode, Intent intent) {
+        if (requestCode == Integer.MIN_VALUE) {
+            BrowserSwitchResult result = BrowserSwitchResult.ERROR
+                    .setErrorMessage("Request code cannot be Integer.MIN_VALUE");
+            return result;
+        }
+
+        if (!isReturnUrlSetup(context)) {
+            BrowserSwitchResult result = BrowserSwitchResult.ERROR
+                    .setErrorMessage("The return url scheme was not set up, incorrectly set up, " +
+                            "or more than one Activity on this device defines the same url " +
+                            "scheme in it's Android Manifest. See " +
+                            "https://github.com/braintree/browser-switch-android for more " +
+                            "information on setting up a return url scheme.");
+            return result;
+        } else if (availableActivities(context.getPackageManager(), intent).size() == 0) {
+            BrowserSwitchResult result = BrowserSwitchResult.ERROR
+                    .setErrorMessage(String.format("No installed activities can open this URL: %s", intent.getData().toString()));
+            return result;
+        }
+
+        return null;
+    }
+
+    public String getReturnUrlScheme(Context context) {
+        return context.getPackageName().toLowerCase().replace("_", "") + ".browserswitch";
+    }
+
+    private boolean isReturnUrlSetup(Context context) {
+        Intent intent = new Intent(Intent.ACTION_VIEW)
+                .setData(Uri.parse(getReturnUrlScheme(context) + "://"))
+                .addCategory(Intent.CATEGORY_DEFAULT)
+                .addCategory(Intent.CATEGORY_BROWSABLE);
+
+        return availableActivities(context.getPackageManager(), intent).size() == 1;
+    }
+
+    private List<ResolveInfo> availableActivities(PackageManager pm, Intent intent) {
+        return pm.queryIntentActivities(intent, 0);
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -9,8 +9,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
+ * @deprecated {@link Fragment} is deprecated in Android P. Use {@link BrowserSwitchSupportFragment}
  * Abstract Fragment that manages the logic for browser switching.
  */
+@Deprecated
 public abstract class BrowserSwitchFragment extends Fragment {
 
     /**

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
@@ -1,0 +1,23 @@
+package com.braintreepayments.browserswitch;
+
+public enum BrowserSwitchResult {
+    OK,
+    CANCELED,
+    ERROR;
+
+    private String mErrorMessage;
+
+    public String getErrorMessage() {
+        return mErrorMessage;
+    }
+
+    BrowserSwitchResult setErrorMessage(String errorMessage) {
+        mErrorMessage = errorMessage;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return name() + " " + getErrorMessage();
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragment.java
@@ -1,19 +1,19 @@
 package com.braintreepayments.browserswitch;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 
 import java.util.List;
 
 /**
  * Abstract Fragment that manages the logic for browser switching.
  */
-public abstract class BrowserSwitchFragment extends Fragment {
+public abstract class BrowserSwitchSupportFragment extends Fragment {
 
     public enum BrowserSwitchResult {
         OK,

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchActivityTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchActivityTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.util.ActivityController;
+import org.robolectric.android.controller.ActivityController;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
@@ -303,6 +303,42 @@ public class BrowserSwitchFragmentTest {
         assertNull(mFragment.returnUri);
     }
 
+    @Test
+    public void browserSwitchResultConvert_whenPassedOK_converts() {
+        BrowserSwitchResult browserSwitchResult = BrowserSwitchResult.OK
+                .setErrorMessage("Error Message is OK");
+
+        BrowserSwitchFragment.BrowserSwitchResult result = BrowserSwitchFragment
+                .BrowserSwitchResult.convert(browserSwitchResult);
+
+        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.OK, result);
+        assertEquals("Error Message is OK", result.getErrorMessage());
+    }
+
+    @Test
+    public void browserSwitchResultConvert_whenPassedCANCELED_converts() {
+        BrowserSwitchResult browserSwitchResult = BrowserSwitchResult.CANCELED
+                .setErrorMessage("Error Message is CANCELED");
+
+        BrowserSwitchFragment.BrowserSwitchResult result = BrowserSwitchFragment
+                .BrowserSwitchResult.convert(browserSwitchResult);
+
+        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.CANCELED, result);
+        assertEquals("Error Message is CANCELED", result.getErrorMessage());
+    }
+
+    @Test
+    public void browserSwitchResultConvert_whenPassedERROR_converts() {
+        BrowserSwitchResult browserSwitchResult = BrowserSwitchResult.ERROR
+                .setErrorMessage("Error Message is ERROR");
+
+        BrowserSwitchFragment.BrowserSwitchResult result = BrowserSwitchFragment
+                .BrowserSwitchResult.convert(browserSwitchResult);
+
+        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, result);
+        assertEquals("Error Message is ERROR", result.getErrorMessage());
+    }
+
     private void mockContext(final Intent intent) {
         ArgumentMatcher<Intent> intentMatcher = new ArgumentMatcher<Intent>() {
             @Override

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragmentTest.java
@@ -8,7 +8,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import com.braintreepayments.browserswitch.test.TestFragmentActivity;
-import com.braintreepayments.browserswitch.test.TestBrowserSwitchFragment;
+import com.braintreepayments.browserswitch.test.TestBrowserSwitchSupportFragment;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -32,17 +32,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-public class BrowserSwitchFragmentTest {
+public class BrowserSwitchSupportFragmentTest {
 
     private TestFragmentActivity mActivity;
-    private TestBrowserSwitchFragment mFragment;
+    private TestBrowserSwitchSupportFragment mFragment;
 
     @Before
     public void setup() {
         BrowserSwitchActivity.clearReturnUri();
 
         mActivity = Robolectric.setupActivity(TestFragmentActivity.class);
-        mFragment = new TestBrowserSwitchFragment();
+        mFragment = new TestBrowserSwitchSupportFragment();
 
         Context mockContext = mock(Context.class);
 
@@ -52,16 +52,16 @@ public class BrowserSwitchFragmentTest {
 
         mFragment.mContext = mockContext;
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(mFragment, "test-fragment")
                 .commit();
     }
 
     @Test
     public void onCreate_setsContext() {
-        BrowserSwitchFragment fragment = new TestBrowserSwitchFragment();
+        BrowserSwitchSupportFragment fragment = new TestBrowserSwitchSupportFragment();
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(fragment, "test-fragment")
                 .commit();
 
@@ -70,11 +70,11 @@ public class BrowserSwitchFragmentTest {
 
     @Test
     public void onCreate_doesNotOverrideContextIfAlreadySet() {
-        mFragment = new TestBrowserSwitchFragment();
+        mFragment = new TestBrowserSwitchSupportFragment();
         Context context = mock(Context.class);
         mFragment.mContext = context;
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(mFragment, "test-fragment")
                 .commit();
 
@@ -131,7 +131,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.CANCELED, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.CANCELED, mFragment.result);
         assertNull(mFragment.returnUri);
     }
 
@@ -143,7 +143,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.OK, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.OK, mFragment.result);
         assertEquals("http://example.com/?key=value", mFragment.returnUri.toString());
     }
 
@@ -237,7 +237,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(Integer.MIN_VALUE, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("Request code cannot be Integer.MIN_VALUE", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }
@@ -251,7 +251,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(Integer.MIN_VALUE, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("Request code cannot be Integer.MIN_VALUE", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }
@@ -262,7 +262,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
                 "Activity on this device defines the same url scheme in it's Android Manifest. " +
                 "See https://github.com/braintree/browser-switch-android for more information on " +
@@ -276,7 +276,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
                 "Activity on this device defines the same url scheme in it's Android Manifest. " +
                 "See https://github.com/braintree/browser-switch-android for more information on " +
@@ -298,7 +298,7 @@ public class BrowserSwitchFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("No installed activities can open this URL: http://example.com/", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchSupportFragmentTest.java
@@ -131,7 +131,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.CANCELED, mFragment.result);
+        assertEquals(BrowserSwitchResult.CANCELED, mFragment.result);
         assertNull(mFragment.returnUri);
     }
 
@@ -143,7 +143,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.OK, mFragment.result);
+        assertEquals(BrowserSwitchResult.OK, mFragment.result);
         assertEquals("http://example.com/?key=value", mFragment.returnUri.toString());
     }
 
@@ -237,7 +237,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(Integer.MIN_VALUE, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("Request code cannot be Integer.MIN_VALUE", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }
@@ -251,7 +251,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(Integer.MIN_VALUE, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("Request code cannot be Integer.MIN_VALUE", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }
@@ -262,7 +262,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
                 "Activity on this device defines the same url scheme in it's Android Manifest. " +
                 "See https://github.com/braintree/browser-switch-android for more information on " +
@@ -276,7 +276,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
                 "Activity on this device defines the same url scheme in it's Android Manifest. " +
                 "See https://github.com/braintree/browser-switch-android for more information on " +
@@ -298,7 +298,7 @@ public class BrowserSwitchSupportFragmentTest {
 
         assertTrue(mFragment.onBrowserSwitchResultCalled);
         assertEquals(42, mFragment.requestCode);
-        assertEquals(BrowserSwitchSupportFragment.BrowserSwitchResult.ERROR, mFragment.result);
+        assertEquals(BrowserSwitchResult.ERROR, mFragment.result);
         assertEquals("No installed activities can open this URL: http://example.com/", mFragment.result.getErrorMessage());
         assertNull(mFragment.returnUri);
     }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchSupportFragment.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchSupportFragment.java
@@ -1,0 +1,23 @@
+package com.braintreepayments.browserswitch.test;
+
+import android.net.Uri;
+import android.support.annotation.Nullable;
+
+import com.braintreepayments.browserswitch.BrowserSwitchSupportFragment;
+
+public class TestBrowserSwitchSupportFragment extends BrowserSwitchSupportFragment {
+
+    public boolean onBrowserSwitchResultCalled = false;
+    public int requestCode;
+    public BrowserSwitchResult result;
+    public Uri returnUri;
+
+    @Override
+    public void onBrowserSwitchResult(int requestCode, BrowserSwitchResult result,
+                                      @Nullable Uri returnUri) {
+        onBrowserSwitchResultCalled = true;
+        this.requestCode = requestCode;
+        this.result = result;
+        this.returnUri = returnUri;
+    }
+}

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchSupportFragment.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchSupportFragment.java
@@ -3,6 +3,7 @@ package com.braintreepayments.browserswitch.test;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
+import com.braintreepayments.browserswitch.BrowserSwitchResult;
 import com.braintreepayments.browserswitch.BrowserSwitchSupportFragment;
 
 public class TestBrowserSwitchSupportFragment extends BrowserSwitchSupportFragment {

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestFragmentActivity.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestFragmentActivity.java
@@ -2,5 +2,5 @@ package com.braintreepayments.browserswitch.test;
 
 import android.app.Activity;
 
-public class TestActivity extends Activity {
+public class TestFragmentActivity extends FragmentActivity {
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestFragmentActivity.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestFragmentActivity.java
@@ -1,6 +1,6 @@
 package com.braintreepayments.browserswitch.test;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 
 public class TestFragmentActivity extends FragmentActivity {
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
     }
 }
@@ -11,8 +12,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-          url 'https://maven.google.com'
-        }
+        google()
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,18 +1,24 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.braintreepayments.browserswitch.demo"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
 }
 
 dependencies {
-    compile project(':browser-switch')
+    implementation project(':browser-switch')
+
+    // Demo should use the latest minor to verify it works with browser-switch
+    // noinspection GradleDynamicVersion
+    implementation 'com.android.support:support-fragment:27.+'
+    // noinspection GradleDynamicVersion
+    implementation 'com.android.support:support-annotations:27.+'
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="Browser Switch Demo">
 
-        <activity android:name=".DemoActivity">
+        <activity android:name=".DemoSupportActivity"/>
+        <activity android:name=".DemoActivity"/>
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportActivity.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportActivity.java
@@ -1,0 +1,17 @@
+package com.braintreepayments.browserswitch.demo;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentActivity;
+
+public class DemoSupportActivity extends FragmentActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        getSupportFragmentManager().beginTransaction()
+                .add(android.R.id.content, new DemoSupportFragment())
+                .commit();
+    }
+}

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.braintreepayments.browserswitch.BrowserSwitchResult;
 import com.braintreepayments.browserswitch.BrowserSwitchSupportFragment;
 
 public class DemoSupportFragment extends BrowserSwitchSupportFragment implements View.OnClickListener {

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoSupportFragment.java
@@ -1,0 +1,46 @@
+package com.braintreepayments.browserswitch.demo;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.braintreepayments.browserswitch.BrowserSwitchSupportFragment;
+
+public class DemoSupportFragment extends BrowserSwitchSupportFragment implements View.OnClickListener {
+
+    private Button mBrowserSwitchButton;
+    private TextView mResult;
+    private TextView mReturnUrl;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.demo_fragment, null);
+
+        mBrowserSwitchButton = (Button) view.findViewById(R.id.browser_switch);
+        mBrowserSwitchButton.setOnClickListener(this);
+
+        mResult = (TextView) view.findViewById(R.id.result);
+        mReturnUrl = (TextView) view.findViewById(R.id.return_url);
+
+        return view;
+    }
+
+    @Override
+    public void onClick(View v) {
+        browserSwitch(1, "https://braintree.github.io/popup-bridge-example/" +
+                "this_launches_in_popup.html?popupBridgeReturnUrlPrefix=" + getReturnUrlScheme()
+                + "://");
+    }
+
+    @Override
+    public void onBrowserSwitchResult(int requestCode, BrowserSwitchResult result, @Nullable Uri returnUri) {
+        mResult.setText("Result: " + result.name());
+        mReturnUrl.setText("Return url: " + returnUri);
+    }
+}

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/MainActivity.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/MainActivity.java
@@ -1,0 +1,25 @@
+package com.braintreepayments.browserswitch.demo;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+
+public class MainActivity extends Activity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+    }
+
+    public void startBrowserSwitchFragment(View view) {
+        Intent demoActivity = new Intent(this, DemoActivity.class);
+        startActivity(demoActivity);
+    }
+
+    public void startBrowserSwitchSupportFragment(View view) {
+        Intent demoSupportActivity = new Intent(this, DemoSupportActivity.class);
+        startActivity(demoSupportActivity);
+    }
+}

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="16dp">
+
+        <Button
+            android:id="@+id/browser_switch_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="startBrowserSwitchFragment"
+            android:text="Browser Switch Fragment"/>
+
+        <Button
+            android:id="@+id/browser_switch_support_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="startBrowserSwitchSupportFragment"
+            android:text="Browser Switch Support Fragment"/>
+
+    </LinearLayout>
+</FrameLayout>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Mar 06 11:14:37 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Android P will deprecate `android.app.Fragment`. This PR adds support for the support fragment `android.support.v4.app.Fragment`

This PR includes
* Updating to SDK 27
* BrowserSwitchSupportFragment which has the same functionality as BrowserSwitchFragment, just inside of a support fragment
* Deprecating BrowserSwitchFragment
* BrowserSwitch package-private class which holds shared logic between the two fragments