### PR TITLE
**Breaking Changes** Migrate to support fragments

### DIFF
--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -16,7 +16,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0-rc02'
+    implementation "androidx.annotation:annotation:${rootProject.ext.androidxVersion}"
+    implementation "androidx.fragment:fragment:${rootProject.ext.androidxVersion}"
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.2.22'

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
@@ -3,7 +3,8 @@ package com.braintreepayments.browserswitch;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 /**
  * <a href="https://developer.android.com/guide/topics/manifest/activity-element.html#lmode">singleTask</a>

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -1,14 +1,15 @@
 package com.braintreepayments.browserswitch;
 
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 
 import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 /**
  * Abstract Fragment that manages the logic for browser switching.

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
@@ -52,7 +52,7 @@ public class BrowserSwitchFragmentTest {
 
         mFragment.mContext = mockContext;
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(mFragment, "test-fragment")
                 .commit();
     }
@@ -61,7 +61,7 @@ public class BrowserSwitchFragmentTest {
     public void onCreate_setsContext() {
         BrowserSwitchFragment fragment = new TestBrowserSwitchFragment();
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(fragment, "test-fragment")
                 .commit();
 
@@ -74,7 +74,7 @@ public class BrowserSwitchFragmentTest {
         Context context = mock(Context.class);
         mFragment.mContext = context;
 
-        mActivity.getFragmentManager().beginTransaction()
+        mActivity.getSupportFragmentManager().beginTransaction()
                 .add(mFragment, "test-fragment")
                 .commit();
 

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestActivity.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestActivity.java
@@ -1,6 +1,6 @@
 package com.braintreepayments.browserswitch.test;
 
-import android.app.Activity;
+import androidx.fragment.app.FragmentActivity;
 
-public class TestActivity extends Activity {
+public class TestActivity extends FragmentActivity {
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchFragment.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/test/TestBrowserSwitchFragment.java
@@ -1,9 +1,10 @@
 package com.braintreepayments.browserswitch.test;
 
 import android.net.Uri;
-import android.support.annotation.Nullable;
 
 import com.braintreepayments.browserswitch.BrowserSwitchFragment;
+
+import androidx.annotation.Nullable;
 
 public class TestBrowserSwitchFragment extends BrowserSwitchFragment {
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,3 +15,7 @@ allprojects {
         jcenter()
     }
 }
+
+ext {
+    androidxVersion = '1.0.0-rc02'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ allprojects {
 }
 
 ext {
-    androidxVersion = '1.0.0-rc02'
+    androidxVersion = '1.0.0'
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -15,7 +15,6 @@ android {
 
 dependencies {
     implementation project(':browser-switch')
-    implementation 'com.android.support:support-annotations:28.0.0-rc02'
     implementation "androidx.annotation:annotation:${rootProject.ext.androidxVersion}"
     implementation "androidx.fragment:fragment:${rootProject.ext.androidxVersion}"
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -16,4 +16,6 @@ android {
 dependencies {
     implementation project(':browser-switch')
     implementation 'com.android.support:support-annotations:28.0.0-rc02'
+    implementation "androidx.annotation:annotation:${rootProject.ext.androidxVersion}"
+    implementation "androidx.fragment:fragment:${rootProject.ext.androidxVersion}"
 }

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
@@ -1,16 +1,17 @@
 package com.braintreepayments.browserswitch.demo;
 
-import android.app.Activity;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 
-public class DemoActivity extends Activity {
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
+public class DemoActivity extends FragmentActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
                 .add(android.R.id.content, new DemoFragment())
                 .commit();
     }

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -2,7 +2,6 @@ package com.braintreepayments.browserswitch.demo;
 
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +9,8 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.braintreepayments.browserswitch.BrowserSwitchFragment;
+
+import androidx.annotation.Nullable;
 
 public class DemoFragment extends BrowserSwitchFragment implements View.OnClickListener {
 


### PR DESCRIPTION
Android P will deprecate `android.app.Fragment`. This PR adds support for the support fragment `androidx.fragment.app.Fragment`

This PR includes:
* **Breaking Change**: Move BrowserSwitchFragment from `android.app.Fragment` to `androidx.fragment.app.Fragment`
* Update Android Plugin for Gradle to 3.1.4
* Uses `androidx` support libraries
* Updating to SDK 28