### PR TITLE
Doc singleInstance activities and browser-switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ If these requirements are not met, an error will be returned and no browser swit
 `BrowserSwitchFragment` is an abstract `androidx.fragment.app.Fragment` that should be extended and used to start and
 handle the response from a browser switch.
 
+**Note**: The `Activity` that `BrowserSwitchFragment` attaches to cannot have a launch mode of `singleInstance`. `BrowserSwitchFragment` needs access to the calling `Activity` to provide a result and cannot do so if the browser switch happens on a different activity stack.
+
 The url scheme to use to return to your app can be retrieved using:
 
 ```java


### PR DESCRIPTION
Issue reported here: https://github.com/braintree/braintree_android/issues/236

Activities that have a `singleInstance` launch mode (i.e. Activity launching on its own activity stack) will start Activities on a different activity stack which prevents Browser Switch from returning a result.