### PR TITLE
Add an instrumentation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # browser-switch-android Release Notes
 
+## TBD
+* Added an instrumentation test for the demo application
+
 ## 1.1.0
 
 * Create `BrowserSwitchOptions` value object for configuring browser switch behavior

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ ext {
     appCompatVersion = "1.1.0"
     annotationVersion = '1.1.0'
     fragmentVersion = '1.2.4'
+    androidxTestRunnerVersion = "1.2.0"
+    androidxTestJunitVersion = "1.1.1"
+    uiAutomatorVersion = "2.2.0"
 }
 
 allprojects {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -29,4 +29,7 @@ dependencies {
     implementation "androidx.fragment:fragment:${rootProject.fragmentVersion}"
 
     androidTestImplementation 'com.lukekorth:device-automator:1.0.0'
+    androidTestImplementation "androidx.test:runner:$androidxTestRunnerVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJunitVersion"
+    androidTestImplementation "androidx.test.uiautomator:uiautomator:$uiAutomatorVersion"
 }

--- a/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/DemoActivityTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/DemoActivityTest.java
@@ -1,0 +1,54 @@
+package com.braintreepayments.browserswitch.demo;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+import androidx.test.uiautomator.Until;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(AndroidJUnit4.class)
+public class DemoActivityTest {
+    private static final long APP_LAUNCH_TIMEOUT_MS = 5000;
+
+    @Test
+    public void testDemo() throws UiObjectNotFoundException {
+        UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        Context context = ApplicationProvider.getApplicationContext();
+
+        // Launch our app using UIAutomator instead of Espresso.
+        // If we use Espresso, our activity is killed when the browser opens.
+        Intent intent = context.getPackageManager().getLaunchIntentForPackage(BuildConfig.APPLICATION_ID);
+        context.startActivity(intent);
+        device.wait(Until.hasObject(By.pkg(BuildConfig.APPLICATION_ID).depth(0)), APP_LAUNCH_TIMEOUT_MS);
+
+        performBrowserSwitch(device, "Red", "red");
+        performBrowserSwitch(device, "Green", "green");
+        performBrowserSwitch(device, "Blue", "blue");
+        performBrowserSwitch(device, "I don't like any of these colors", "undefined");
+    }
+
+    private void performBrowserSwitch(UiDevice device,
+                                      String colorActionLabel,
+                                      String expectedSelectedColor) throws UiObjectNotFoundException {
+        Application application = ApplicationProvider.getApplicationContext();
+        device.findObject(By.res(BuildConfig.APPLICATION_ID, "browser_switch")).click();
+        UiSelector selector = new UiSelector();
+        device.findObject(selector.text(colorActionLabel)).click();
+        assertTrue(device.findObject(selector.text(application.getString(R.string.browser_switch_success_text))).exists());
+        assertTrue(device.findObject(selector.text(application.getString(R.string.browser_switch_selected_color_text, expectedSelectedColor))).exists());
+    }
+
+}

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -101,18 +101,18 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
         int statusCode = result.getStatus();
         switch (statusCode) {
             case BrowserSwitchResult.STATUS_OK:
-                resultText = "Browser Switch Successful";
+                resultText = getString(R.string.browser_switch_success_text);
 
                 if (returnUri != null) {
                     String color = returnUri.getQueryParameter("color");
-                    selectedColorText = String.format("Selected color: %s", color);
+                    selectedColorText = getString(R.string.browser_switch_selected_color_text, color);
                 }
                 break;
             case BrowserSwitchResult.STATUS_ERROR:
-                resultText = "Browser Switch Error: " + result.getErrorMessage();
+                resultText = getString(R.string.browser_switch_error_text, result.getErrorMessage());
                 break;
             case BrowserSwitchResult.STATUS_CANCELED:
-                resultText = "Browser Switch Cancelled by User";
+                resultText = getString(R.string.browser_switch_cancel_text);
                 break;
         }
         mBrowserSwitchStatusTextView.setText(resultText);

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
 <resources>
     <string name="browser_switch_btn_text">Start Browser Switch</string>
     <string name="browser_switch_with_metadata_btn_text">Start Browser Switch With Metadata</string>
+    <string name="browser_switch_selected_color_text">Selected color: %s</string>
+    <string name="browser_switch_success_text">Browser Switch Successful</string>
+    <string name="browser_switch_error_text">Browser Switch Error: %s</string>
+    <string name="browser_switch_cancel_text">Browser Switch Cancelled by User</string>
 </resources>


### PR DESCRIPTION
In case you find it useful, here's a suggestion of an instrumentation test. To catch a mistake like the one I did in PR #18 :smile: (forgetting to add `singleTask`).

----
Summary:

* Use UIAutomator instead of Espresso, since we need to interact with an external app (the browser).
* ~Add a `AndroidManifest.xml` for instrumentation tests which overrides the default `AndroidManifest.xml`, to avoid a build error regarding the `minSdkVersion`. A `minSdkVersion` of 18 is required to use UIAutomator, but this project's `minSdkVersion` is 15.~
* Use string resources, instead of string literals, in `DemoFragment`, so we can use the same strings in `DemoActivityTest`

----

* Note: I would have preferred to add the test in Kotlin, but didn't since Kotlin isn't used in this project yet. Didn't want to impose this as part of this PR.
* Note: This test also passes if integrated to the PR #18 (custom tabs in the same activity stack). It will fail in that branch if the `singleTask` mode is removed from `DemoActivity`.
* Note: ⚠️ This test relies on strings external to this repository: the strings in the [sample browser switch webpage](https://braintree.github.io/popup-bridge-example/this_launches_in_popup.html). So if anything changes in that page, this test can fail.