### PR TITLE
Prevent multiple DemoFragment instances from being created

### DIFF
--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
@@ -11,8 +11,10 @@ public class DemoActivity extends FragmentActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        getSupportFragmentManager().beginTransaction()
-                .add(android.R.id.content, new DemoFragment())
-                .commit();
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .add(android.R.id.content, new DemoFragment())
+                    .commit();
+        }
     }
 }

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoActivity.java
@@ -4,16 +4,20 @@ import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 public class DemoActivity extends FragmentActivity {
+
+    private static final String FRAGMENT_TAG = DemoFragment.class.getSimpleName();
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
-            getSupportFragmentManager().beginTransaction()
-                    .add(android.R.id.content, new DemoFragment())
+        FragmentManager fm = getSupportFragmentManager();
+        if (fm.findFragmentByTag(FRAGMENT_TAG) == null) {
+            fm.beginTransaction()
+                    .add(android.R.id.content, new DemoFragment(), FRAGMENT_TAG)
                     .commit();
         }
     }


### PR DESCRIPTION
Steps to reproduce the issue:
* Add a log to `BrowserSwitchFragment.onResume()`:
    ```
    Log.d("BrowserSwitchFragment","onResume " + this);
    ```
* Build and install the app
* Launch the app
* Monitor logcat
* Rotate the device multiple times
* Expected behavior: Each time you rotate, you only see one additional log like:
    ```
    04-17 11:26:24.201 30906 30906 D BrowserSwitchFragment: onResume DemoFragment{f089136 #0 id=0x1020002}
    ```
* Actual behavior: Each time you rotate, the number of additional `onResume` logs increases. 1 rotation = 2 additional logs, 2 rotations = 3 additional logs, 3 rotations = 4 additional logs, etc.

To fix this, only add the fragment if `savedInstanceState` is null. We know the fragment will already be present if `savedInstanceState` is not null, because the `FragmentActivity.onCreate()` implementation will have restored it from the saved state.