### PR TITLE
Request Metadata via BrowserSwitchOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Create `BrowserSwitchOptions` value object for configuring browser switch behavior
 * Add BrowserSwitchClient#start overloads with `BrowserSwitchOptions` param
 * Add BrowserSwitchFragment#browserSwitch overload with `BrowserSwitchOptions` param
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Add BrowserSwitchClient#start overloads with `BrowserSwitchOptions` param
+* Add BrowserSwitchFragment#browserSwitch overload with `BrowserSwitchOptions` param
+
 ## 1.0.0
 
 * Create BrowserSwitchClient to allow browser switch behavior through composition as well as inheritance.

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+
     testImplementation 'org.robolectric:robolectric:4.3'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
@@ -109,7 +111,6 @@ afterEvaluate {
                         url = 'scm:git@github.com:braintree/browser-switch-android.git'
                         connection = 'scm:git@github.com:braintree/browser-switch-android.git'
                         developerConnection = 'scm:git@github.com:braintree/browser-switch-android.git'
-
                     }
 
                     developers {

--- a/browser-switch/src/androidTest/java/com/braintreepayments/browserswitch/ChromeCustomTabsTest.java
+++ b/browser-switch/src/androidTest/java/com/braintreepayments/browserswitch/ChromeCustomTabsTest.java
@@ -8,7 +8,6 @@ import androidx.fragment.app.testing.FragmentScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SdkSuppress;
 
-import com.braintreepayments.browserswitch.test.BuildConfig;
 import com.braintreepayments.browserswitch.test.TestBrowserSwitchFragment;
 
 import org.junit.Before;

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -9,8 +9,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
-import org.json.JSONObject;
-
 @SuppressWarnings("WeakerAccess")
 public class BrowserSwitchClient {
 
@@ -50,16 +48,11 @@ public class BrowserSwitchClient {
      * @param fragment the fragment used to start browser switch
      */
     public void start(int requestCode, Uri uri, Fragment fragment) {
-        if (fragment instanceof BrowserSwitchListener) {
-            start(requestCode, uri, fragment, (BrowserSwitchListener) fragment);
-        } else {
-            throw new IllegalArgumentException("Fragment must implement BrowserSwitchListener.");
-        }
-    }
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(requestCode)
+                .url(uri);
 
-    // TODO: write docs
-    public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment) {
-        // TODO: implement
+        start(browserSwitchOptions, fragment);
     }
 
     /**
@@ -72,17 +65,11 @@ public class BrowserSwitchClient {
      * @param listener the listener that will receive browser switch callbacks
      */
     public void start(int requestCode, Uri uri, Fragment fragment, BrowserSwitchListener listener) {
-        FragmentActivity activity = fragment.getActivity();
-        if (activity != null) {
-            start(requestCode, uri, activity, listener);
-        } else {
-            throw new IllegalStateException("Fragment must be attached to an activity.");
-        }
-    }
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(requestCode)
+                .url(uri);
 
-    // TODO: write docs
-    public void start(int requestCode, Uri uri, Fragment fragment, BrowserSwitchListener listener, JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, fragment, listener);
     }
 
     /**
@@ -95,16 +82,11 @@ public class BrowserSwitchClient {
      */
     @SuppressWarnings("SameParameterValue")
     public void start(int requestCode, Uri uri, FragmentActivity activity) {
-        if (activity instanceof BrowserSwitchListener) {
-            start(requestCode, uri, activity, (BrowserSwitchListener) activity);
-        } else {
-            throw new IllegalArgumentException("Activity must implement BrowserSwitchListener.");
-        }
-    }
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(requestCode)
+                .url(uri);
 
-    // TODO: write docs
-    public void start(int requestCode, Uri uri, FragmentActivity activity, JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, activity);
     }
 
     /**
@@ -116,17 +98,12 @@ public class BrowserSwitchClient {
      * @param activity the activity used to start browser switch
      * @param listener the listener that will receive browser switch callbacks
      */
-    public void start(
-            int requestCode, Uri uri, FragmentActivity activity,BrowserSwitchListener listener) {
-        Context appContext = activity.getApplicationContext();
-        Intent intent = config.createIntentToLaunchUriInBrowser(appContext, uri);
-        start(requestCode, intent, activity, listener);
-    }
+    public void start(int requestCode, Uri uri, FragmentActivity activity, BrowserSwitchListener listener) {
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(requestCode)
+                .url(uri);
 
-    // TODO: write docs
-    public void start(int requestCode, Uri uri, FragmentActivity activity,
-                      BrowserSwitchListener listener, JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, activity, listener);
     }
 
     /**
@@ -138,16 +115,11 @@ public class BrowserSwitchClient {
      * @param fragment the fragment used to start browser switch
      */
     public void start(int requestCode, Intent intent, Fragment fragment) {
-        if (fragment instanceof BrowserSwitchListener) {
-            start(requestCode, intent, fragment, (BrowserSwitchListener) fragment);
-        } else {
-            throw new IllegalArgumentException("Fragment must implement BrowserSwitchListener.");
-        }
-    }
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .intent(intent)
+                .requestCode(requestCode);
 
-    // TODO: write docs
-    public void start(int requestCode, Intent intent, Fragment fragment, JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, fragment);
     }
 
     /**
@@ -159,20 +131,12 @@ public class BrowserSwitchClient {
      * @param fragment the fragment used to start browser switch
      * @param listener the listener that will receive browser switch callbacks
      */
-    public void start(
-        int requestCode, Intent intent, Fragment fragment, BrowserSwitchListener listener) {
-        FragmentActivity activity = fragment.getActivity();
-        if (activity != null) {
-            start(requestCode, intent, activity, listener);
-        } else {
-            throw new IllegalStateException("Fragment must be attached to an activity.");
-        }
-    }
+    public void start(int requestCode, Intent intent, Fragment fragment, BrowserSwitchListener listener) {
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .intent(intent)
+                .requestCode(requestCode);
 
-    // TODO: write docs
-    public void start(int requestCode, Intent intent, Fragment fragment,
-        BrowserSwitchListener listener, JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, fragment, listener);
     }
 
     /**
@@ -185,17 +149,11 @@ public class BrowserSwitchClient {
      */
     @SuppressWarnings("SameParameterValue")
     public void start(int requestCode, Intent intent, FragmentActivity activity) {
-        if (activity instanceof BrowserSwitchListener) {
-            start(requestCode, intent, activity, (BrowserSwitchListener) activity);
-        } else {
-            throw new IllegalArgumentException("Activity must implement BrowserSwitchListener.");
-        }
-    }
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .intent(intent)
+                .requestCode(requestCode);
 
-    // TODO: write docs
-    public void start(int requestCode, Intent intent, FragmentActivity activity,
-        JSONObject metadata) {
-        // TODO: implement
+        start(browserSwitchOptions, activity);
     }
 
     /**
@@ -207,9 +165,55 @@ public class BrowserSwitchClient {
      * @param activity the activity used to start browser switch
      * @param listener the listener that will receive browser switch callbacks
      */
-    public void start(
-        int requestCode, Intent intent, FragmentActivity activity, BrowserSwitchListener listener) {
+    public void start(int requestCode, Intent intent, FragmentActivity activity, BrowserSwitchListener listener) {
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .intent(intent)
+                .requestCode(requestCode);
+
+        start(browserSwitchOptions, activity, listener);
+    }
+
+    // TODO: write docs
+    public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment) {
+        if (fragment instanceof BrowserSwitchListener) {
+            start(browserSwitchOptions, fragment, (BrowserSwitchListener) fragment);
+        } else {
+            throw new IllegalArgumentException("Fragment must implement BrowserSwitchListener.");
+        }
+    }
+
+    // TODO: write docs
+    public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment, BrowserSwitchListener listener) {
+        FragmentActivity activity = fragment.getActivity();
+        if (activity != null) {
+            start(browserSwitchOptions, activity, listener);
+        } else {
+            throw new IllegalStateException("Fragment must be attached to an activity.");
+        }
+    }
+
+    // TODO: write docs
+    public void start(BrowserSwitchOptions browserSwitchOptions, FragmentActivity activity) {
+        if (activity instanceof BrowserSwitchListener) {
+            start(browserSwitchOptions, activity, (BrowserSwitchListener) activity);
+        } else {
+            throw new IllegalArgumentException("Activity must implement BrowserSwitchListener.");
+        }
+    }
+
+    // TODO: write docs
+    public void start(BrowserSwitchOptions browserSwitchOptions, FragmentActivity activity, BrowserSwitchListener listener) {
         Context appContext = activity.getApplicationContext();
+
+        Intent intent;
+        if(browserSwitchOptions.getIntent() != null) {
+            intent = browserSwitchOptions.getIntent();
+        } else {
+            intent = config.createIntentToLaunchUriInBrowser(appContext, browserSwitchOptions.getUrl());
+        }
+
+        int requestCode = browserSwitchOptions.getRequestCode();
+
         String errorMessage = assertCanPerformBrowserSwitch(requestCode, appContext, intent);
         if (errorMessage == null) {
             BrowserSwitchRequest request = new BrowserSwitchRequest(
@@ -218,15 +222,9 @@ public class BrowserSwitchClient {
             appContext.startActivity(intent);
         } else {
             BrowserSwitchResult result =
-                new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
+                    new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
             listener.onBrowserSwitchResult(requestCode, result, null);
         }
-    }
-
-    // TODO: write docs
-    public void start(int requestCode, Intent intent, FragmentActivity activity,
-        BrowserSwitchListener listener, JSONObject metadata) {
-        // TODO: implement
     }
 
     private String assertCanPerformBrowserSwitch(int requestCode, Context context, Intent intent) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -9,6 +9,8 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import org.json.JSONObject;
+
 @SuppressWarnings("WeakerAccess")
 public class BrowserSwitchClient {
 
@@ -55,6 +57,11 @@ public class BrowserSwitchClient {
         }
     }
 
+    // TODO: write docs
+    public void start(int requestCode, Uri uri, Fragment fragment, JSONObject metadata) {
+        // TODO: implement
+    }
+
     /**
      * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
      * with the given url from an Android fragment. The fragment must be attached to activity when invoking this method.
@@ -71,6 +78,11 @@ public class BrowserSwitchClient {
         } else {
             throw new IllegalStateException("Fragment must be attached to an activity.");
         }
+    }
+
+    // TODO: write docs
+    public void start(int requestCode, Uri uri, Fragment fragment, BrowserSwitchListener listener, JSONObject metadata) {
+        // TODO: implement
     }
 
     /**
@@ -90,6 +102,11 @@ public class BrowserSwitchClient {
         }
     }
 
+    // TODO: write docs
+    public void start(int requestCode, Uri uri, FragmentActivity activity, JSONObject metadata) {
+        // TODO: implement
+    }
+
     /**
      * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
      * with the given url from an Android activity.
@@ -100,10 +117,16 @@ public class BrowserSwitchClient {
      * @param listener the listener that will receive browser switch callbacks
      */
     public void start(
-        int requestCode, Uri uri, FragmentActivity activity, BrowserSwitchListener listener) {
+            int requestCode, Uri uri, FragmentActivity activity,BrowserSwitchListener listener) {
         Context appContext = activity.getApplicationContext();
         Intent intent = config.createIntentToLaunchUriInBrowser(appContext, uri);
         start(requestCode, intent, activity, listener);
+    }
+
+    // TODO: write docs
+    public void start(int requestCode, Uri uri, FragmentActivity activity,
+                      BrowserSwitchListener listener, JSONObject metadata) {
+        // TODO: implement
     }
 
     /**
@@ -120,6 +143,11 @@ public class BrowserSwitchClient {
         } else {
             throw new IllegalArgumentException("Fragment must implement BrowserSwitchListener.");
         }
+    }
+
+    // TODO: write docs
+    public void start(int requestCode, Intent intent, Fragment fragment, JSONObject metadata) {
+        // TODO: implement
     }
 
     /**
@@ -141,6 +169,12 @@ public class BrowserSwitchClient {
         }
     }
 
+    // TODO: write docs
+    public void start(int requestCode, Intent intent, Fragment fragment,
+        BrowserSwitchListener listener, JSONObject metadata) {
+        // TODO: implement
+    }
+
     /**
      * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
      * with the given intent from an Android activity.
@@ -156,6 +190,12 @@ public class BrowserSwitchClient {
         } else {
             throw new IllegalArgumentException("Activity must implement BrowserSwitchListener.");
         }
+    }
+
+    // TODO: write docs
+    public void start(int requestCode, Intent intent, FragmentActivity activity,
+        JSONObject metadata) {
+        // TODO: implement
     }
 
     /**
@@ -181,6 +221,12 @@ public class BrowserSwitchClient {
                 new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
             listener.onBrowserSwitchResult(requestCode, result, null);
         }
+    }
+
+    // TODO: write docs
+    public void start(int requestCode, Intent intent, FragmentActivity activity,
+        BrowserSwitchListener listener, JSONObject metadata) {
+        // TODO: implement
     }
 
     private String assertCanPerformBrowserSwitch(int requestCode, Context context, Intent intent) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -218,8 +218,9 @@ public class BrowserSwitchClient {
 
         String errorMessage = assertCanPerformBrowserSwitch(requestCode, appContext, intent);
         if (errorMessage == null) {
+            JSONObject metadata = browserSwitchOptions.getMetadata();
             BrowserSwitchRequest request = new BrowserSwitchRequest(
-                    requestCode, intent.getData(), BrowserSwitchRequest.PENDING, null);
+                    requestCode, intent.getData(), BrowserSwitchRequest.PENDING, metadata);
             persistentStore.putActiveRequest(request, appContext);
             appContext.startActivity(intent);
         } else {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -47,7 +47,7 @@ public class BrowserSwitchClient {
      *
      * @param requestCode the request code used to differentiate requests from one another.
      * @param uri the url to open.
-     * @param fragment the fragment used to start browser switch
+     * @param fragment the fragment used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(int requestCode, Uri uri, Fragment fragment) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
@@ -80,7 +80,7 @@ public class BrowserSwitchClient {
      *
      * @param requestCode the request code used to differentiate requests from one another.
      * @param uri the url to open.
-     * @param activity the activity used to start browser switch
+     * @param activity the activity used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(int requestCode, Uri uri, FragmentActivity activity) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
@@ -113,7 +113,7 @@ public class BrowserSwitchClient {
      *
      * @param requestCode the request code used to differentiate requests from one another.
      * @param intent the intent to use to initiate a browser switch
-     * @param fragment the fragment used to start browser switch
+     * @param fragment the fragment used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(int requestCode, Intent intent, Fragment fragment) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
@@ -146,7 +146,7 @@ public class BrowserSwitchClient {
      *
      * @param requestCode the request code used to differentiate requests from one another.
      * @param intent the intent to use to initiate a browser switch
-     * @param activity the activity used to start browser switch
+     * @param activity the activity used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(int requestCode, Intent intent, FragmentActivity activity) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
@@ -179,7 +179,7 @@ public class BrowserSwitchClient {
      * must be attached to activity when invoking this method.
      *
      * @param browserSwitchOptions {@link BrowserSwitchOptions}
-     * @param fragment the fragment used to start browser switch
+     * @param fragment the fragment used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment) {
         if (fragment instanceof BrowserSwitchListener) {
@@ -212,7 +212,7 @@ public class BrowserSwitchClient {
      * with a given set of {@link BrowserSwitchOptions} from an Android activity.
      *
      * @param browserSwitchOptions {@link BrowserSwitchOptions}
-     * @param activity the activity used to start browser switch
+     * @param activity the activity used to start browser switch. Must implement {@link BrowserSwitchListener}
      */
     public void start(BrowserSwitchOptions browserSwitchOptions, FragmentActivity activity) {
         if (activity instanceof BrowserSwitchListener) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -173,7 +173,14 @@ public class BrowserSwitchClient {
         start(browserSwitchOptions, activity, listener);
     }
 
-    // TODO: write docs
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android fragment. The fragment
+     * must be attached to activity when invoking this method.
+     *
+     * @param browserSwitchOptions {@link BrowserSwitchOptions}
+     * @param fragment the fragment used to start browser switch
+     */
     public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment) {
         if (fragment instanceof BrowserSwitchListener) {
             start(browserSwitchOptions, fragment, (BrowserSwitchListener) fragment);
@@ -182,7 +189,15 @@ public class BrowserSwitchClient {
         }
     }
 
-    // TODO: write docs
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android fragment. The fragment
+     * must be attached to activity when invoking this method.
+     *
+     * @param browserSwitchOptions {@link BrowserSwitchOptions}
+     * @param fragment the fragment used to start browser switch
+     * @param listener the listener that will receive browser switch callbacks
+     */
     public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment, BrowserSwitchListener listener) {
         FragmentActivity activity = fragment.getActivity();
         if (activity != null) {
@@ -192,7 +207,13 @@ public class BrowserSwitchClient {
         }
     }
 
-    // TODO: write docs
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android activity.
+     *
+     * @param browserSwitchOptions {@link BrowserSwitchOptions}
+     * @param activity the activity used to start browser switch
+     */
     public void start(BrowserSwitchOptions browserSwitchOptions, FragmentActivity activity) {
         if (activity instanceof BrowserSwitchListener) {
             start(browserSwitchOptions, activity, (BrowserSwitchListener) activity);
@@ -201,7 +222,14 @@ public class BrowserSwitchClient {
         }
     }
 
-    // TODO: write docs
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android activity.
+     *
+     * @param browserSwitchOptions {@link BrowserSwitchOptions}
+     * @param activity the activity used to start browser switch
+     * @param listener the listener that will receive browser switch callbacks
+     */
     public void start(BrowserSwitchOptions browserSwitchOptions, FragmentActivity activity, BrowserSwitchListener listener) {
         Context appContext = activity.getApplicationContext();
 

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -9,6 +9,8 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import org.json.JSONObject;
+
 @SuppressWarnings("WeakerAccess")
 public class BrowserSwitchClient {
 
@@ -338,11 +340,15 @@ public class BrowserSwitchClient {
 
             Uri uri = null;
             BrowserSwitchResult result;
+
+            JSONObject metadata = request.getMetadata();
             if (request.getState().equalsIgnoreCase(BrowserSwitchRequest.SUCCESS)) {
                 uri = request.getUri();
-                result = new BrowserSwitchResult(BrowserSwitchResult.STATUS_OK);
+                result = new BrowserSwitchResult(
+                        BrowserSwitchResult.STATUS_OK, null, metadata);
             } else {
-                result = new BrowserSwitchResult(BrowserSwitchResult.STATUS_CANCELED);
+                result = new BrowserSwitchResult(
+                        BrowserSwitchResult.STATUS_CANCELED, null, metadata);
             }
             listener.onBrowserSwitchResult(requestCode, result, uri);
         }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -58,7 +58,7 @@ public class BrowserSwitchClient {
     }
 
     // TODO: write docs
-    public void start(int requestCode, Uri uri, Fragment fragment, JSONObject metadata) {
+    public void start(BrowserSwitchOptions browserSwitchOptions, Fragment fragment) {
         // TODO: implement
     }
 

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -82,7 +82,6 @@ public class BrowserSwitchClient {
      * @param uri the url to open.
      * @param activity the activity used to start browser switch
      */
-    @SuppressWarnings("SameParameterValue")
     public void start(int requestCode, Uri uri, FragmentActivity activity) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .requestCode(requestCode)
@@ -149,7 +148,6 @@ public class BrowserSwitchClient {
      * @param intent the intent to use to initiate a browser switch
      * @param activity the activity used to start browser switch
      */
-    @SuppressWarnings("SameParameterValue")
     public void start(int requestCode, Intent intent, FragmentActivity activity) {
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .intent(intent)

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -251,7 +251,7 @@ public class BrowserSwitchClient {
             appContext.startActivity(intent);
         } else {
             BrowserSwitchResult result =
-                    new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
+                new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
             listener.onBrowserSwitchResult(requestCode, result, null);
         }
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -217,7 +217,7 @@ public class BrowserSwitchClient {
         String errorMessage = assertCanPerformBrowserSwitch(requestCode, appContext, intent);
         if (errorMessage == null) {
             BrowserSwitchRequest request = new BrowserSwitchRequest(
-                    requestCode, intent.getData(), BrowserSwitchRequest.PENDING);
+                    requestCode, intent.getData(), BrowserSwitchRequest.PENDING, null);
             persistentStore.putActiveRequest(request, appContext);
             appContext.startActivity(intent);
         } else {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -74,7 +74,12 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
         browserSwitchClient.start(browserSwitchOptions, this);
     }
 
-    //TODO: write docs
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with the given intent.
+     *
+     * @param browserSwitchOptions a {@link BrowserSwitchOptions} object.
+     */
     public void browserSwitch(BrowserSwitchOptions browserSwitchOptions) {
         browserSwitchClient.start(browserSwitchOptions, this);
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -53,7 +53,10 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
      */
     @SuppressWarnings("WeakerAccess")
     public void browserSwitch(int requestCode, String url) {
-        browserSwitchClient.start(requestCode, Uri.parse(url), this);
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(requestCode)
+                .url(Uri.parse(url));
+        browserSwitchClient.start(browserSwitchOptions, this);
     }
 
     /**
@@ -65,7 +68,10 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
      */
     @SuppressWarnings("WeakerAccess")
     public void browserSwitch(int requestCode, Intent intent) {
-        browserSwitchClient.start(requestCode, intent, this);
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .intent(intent)
+                .requestCode(requestCode);
+        browserSwitchClient.start(browserSwitchOptions, this);
     }
 
     //TODO: write docs

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -68,6 +68,11 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
         browserSwitchClient.start(requestCode, intent, this);
     }
 
+    //TODO: write docs
+    public void browserSwitch(BrowserSwitchOptions browserSwitchOptions) {
+        browserSwitchClient.start(browserSwitchOptions, this);
+    }
+
     /**
      * The result of a browser switch will be returned in this method.
      *

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -3,8 +3,15 @@ package com.braintreepayments.browserswitch;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.fragment.app.FragmentActivity;
+
 import org.json.JSONObject;
 
+/**
+ * Parameter object that contains a set of BrowserSwitch parameters for use with
+ * {@link BrowserSwitchClient#start(BrowserSwitchOptions, FragmentActivity, BrowserSwitchListener)}
+ * and related convenience methods.
+ */
 public class BrowserSwitchOptions {
 
     private Intent intent;

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -1,14 +1,21 @@
 package com.braintreepayments.browserswitch;
 
+import android.content.Intent;
 import android.net.Uri;
 
 import org.json.JSONObject;
 
 public class BrowserSwitchOptions {
 
+    private Intent intent;
+    private JSONObject metadata;
     private int requestCode;
     private Uri url;
-    private JSONObject metadata;
+
+    public BrowserSwitchOptions intent(Intent intent) {
+        this.intent = intent;
+        return this;
+    }
 
     public BrowserSwitchOptions metadata(JSONObject metadata) {
         this.metadata = metadata;
@@ -23,6 +30,10 @@ public class BrowserSwitchOptions {
     public BrowserSwitchOptions url(Uri url) {
         this.url = url;
         return this;
+    }
+
+    public Intent getIntent() {
+        return intent;
     }
 
     public JSONObject getMetadata() {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -1,25 +1,39 @@
 package com.braintreepayments.browserswitch;
 
+import android.net.Uri;
+
+import org.json.JSONObject;
+
 public class BrowserSwitchOptions {
 
     private int requestCode;
-    private String url;
+    private Uri url;
+    private JSONObject metadata;
+
+    public BrowserSwitchOptions metadata(JSONObject metadata) {
+        this.metadata = metadata;
+        return this;
+    }
 
     public BrowserSwitchOptions requestCode(int requestCode) {
         this.requestCode = requestCode;
         return this;
     }
 
-    public int getRequestCode() {
-        return requestCode;
-    }
-
-    public BrowserSwitchOptions url(String url) {
+    public BrowserSwitchOptions url(Uri url) {
         this.url = url;
         return this;
     }
 
-    public String getUrl() {
+    public JSONObject getMetadata() {
+        return metadata;
+    }
+
+    public int getRequestCode() {
+        return requestCode;
+    }
+
+    public Uri getUrl() {
         return url;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -1,0 +1,25 @@
+package com.braintreepayments.browserswitch;
+
+public class BrowserSwitchOptions {
+
+    private int requestCode;
+    private String url;
+
+    public BrowserSwitchOptions requestCode(int requestCode) {
+        this.requestCode = requestCode;
+        return this;
+    }
+
+    public int getRequestCode() {
+        return requestCode;
+    }
+
+    public BrowserSwitchOptions url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -31,7 +31,7 @@ public class BrowserSwitchOptions {
 
     /**
      * Set browser switch metadata
-     * @param metadata JSONObject containing metadata to associate with the browser switch request
+     * @param metadata JSONObject containing metadata necessary for handling the return from browser to app. This data will be persisted and returned in {@link BrowserSwitchResult} even if the app is terminated during the browser switch.
      * @return {@link BrowserSwitchOptions} returns reference to instance to allow setter invocations to be chained
      */
     public BrowserSwitchOptions metadata(JSONObject metadata) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchOptions.java
@@ -19,38 +19,70 @@ public class BrowserSwitchOptions {
     private int requestCode;
     private Uri url;
 
+    /**
+     * Set browser switch intent
+     * @param intent The target intent to use for browser switch. Required unless url specified
+     * @return {@link BrowserSwitchOptions} returns reference to instance to allow setter invocations to be chained
+     */
     public BrowserSwitchOptions intent(Intent intent) {
         this.intent = intent;
         return this;
     }
 
+    /**
+     * Set browser switch metadata
+     * @param metadata JSONObject containing metadata to associate with the browser switch request
+     * @return {@link BrowserSwitchOptions} returns reference to instance to allow setter invocations to be chained
+     */
     public BrowserSwitchOptions metadata(JSONObject metadata) {
         this.metadata = metadata;
         return this;
     }
 
+    /**
+     * Set browser switch request code
+     * @param requestCode Request code int to associate with the browser switch request
+     * @return {@link BrowserSwitchOptions} returns reference to instance to allow setter invocations to be chained
+     */
     public BrowserSwitchOptions requestCode(int requestCode) {
         this.requestCode = requestCode;
         return this;
     }
 
+    /**
+     * Set browser switch url
+     * @param url The target url to use for browser switch. Required unless intent specified
+     * @return {@link BrowserSwitchOptions} returns reference to instance to allow setter invocations to be chained
+     */
     public BrowserSwitchOptions url(Uri url) {
         this.url = url;
         return this;
     }
 
+    /**
+     * @return The target intent used for browser switch
+     */
     public Intent getIntent() {
         return intent;
     }
 
+    /**
+     * @return The metadata associated with the browser switch request
+     */
     public JSONObject getMetadata() {
         return metadata;
     }
 
+    /**
+     * @return The request code associated with the browser switch request
+     */
     public int getRequestCode() {
         return requestCode;
     }
 
+    /**
+     * @return The target url used for browser switch
+     */
     public Uri getUrl() {
         return url;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchPersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchPersistentStore.java
@@ -1,12 +1,17 @@
 package com.braintreepayments.browserswitch;
 
 import android.content.Context;
+import android.util.Log;
 
 import androidx.annotation.VisibleForTesting;
 
 import org.json.JSONException;
 
+import java.util.Arrays;
+
 class BrowserSwitchPersistentStore {
+
+    private static final String TAG = "BrowserSwitch";
 
     @VisibleForTesting
     static final String REQUEST_KEY = "browserSwitch.request";
@@ -26,7 +31,10 @@ class BrowserSwitchPersistentStore {
         if (activeRequestJson != null) {
             try {
                 request = BrowserSwitchRequest.fromJson(activeRequestJson);
-            } catch (JSONException ignored) { /* do nothing */ }
+            } catch (JSONException e) {
+                Log.d(TAG, e.getMessage());
+                Log.d(TAG, Arrays.toString(e.getStackTrace()));
+            }
         }
         return request;
     }
@@ -34,7 +42,10 @@ class BrowserSwitchPersistentStore {
     void putActiveRequest(BrowserSwitchRequest request, Context context) {
         try {
             PersistentStore.put(REQUEST_KEY, request.toJson(), context);
-        } catch (JSONException ignored) { /* do nothing */ }
+        } catch (JSONException e) {
+            Log.d(TAG, e.getMessage());
+            Log.d(TAG, Arrays.toString(e.getStackTrace()));
+        }
     }
 
     void clearActiveRequest(Context context) {

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
@@ -51,10 +51,6 @@ class BrowserSwitchRequest {
         return metadata;
     }
 
-    public void setMetadata(JSONObject metadata) {
-        this.metadata = metadata;
-    }
-
     void setState(String state) {
         this.state = state;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
@@ -10,6 +10,7 @@ class BrowserSwitchRequest {
     private Uri uri;
     private String state;
     final private int requestCode;
+    private JSONObject metadata;
 
     static final String PENDING = "PENDING";
     static final String SUCCESS = "SUCCESS";
@@ -19,13 +20,15 @@ class BrowserSwitchRequest {
         int requestCode = jsonObject.getInt("requestCode");
         String url = jsonObject.getString("url");
         String state = jsonObject.getString("state");
-        return new BrowserSwitchRequest(requestCode, Uri.parse(url), state);
+        JSONObject metadata = jsonObject.getJSONObject("metadata");
+        return new BrowserSwitchRequest(requestCode, Uri.parse(url), state, metadata);
     }
 
-    BrowserSwitchRequest(int requestCode, Uri uri, String state) {
+    BrowserSwitchRequest(int requestCode, Uri uri, String state, JSONObject metadata) {
         this.uri = uri;
         this.state = state;
         this.requestCode = requestCode;
+        this.metadata = metadata;
     }
 
     void setUri(Uri value) {
@@ -44,6 +47,14 @@ class BrowserSwitchRequest {
         return state;
     }
 
+    public JSONObject getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JSONObject metadata) {
+        this.metadata = metadata;
+    }
+
     void setState(String state) {
         this.state = state;
     }
@@ -53,6 +64,7 @@ class BrowserSwitchRequest {
         result.put("requestCode", requestCode);
         result.put("url", uri.toString());
         result.put("state", state);
+        result.put("metadata", metadata);
         return result.toString();
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchRequest.java
@@ -20,7 +20,7 @@ class BrowserSwitchRequest {
         int requestCode = jsonObject.getInt("requestCode");
         String url = jsonObject.getString("url");
         String state = jsonObject.getString("state");
-        JSONObject metadata = jsonObject.getJSONObject("metadata");
+        JSONObject metadata = jsonObject.optJSONObject("metadata");
         return new BrowserSwitchRequest(requestCode, Uri.parse(url), state, metadata);
     }
 
@@ -64,7 +64,9 @@ class BrowserSwitchRequest {
         result.put("requestCode", requestCode);
         result.put("url", uri.toString());
         result.put("state", state);
-        result.put("metadata", metadata);
+        if (metadata != null) {
+            result.put("metadata", metadata);
+        }
         return result.toString();
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
@@ -21,10 +21,6 @@ public class BrowserSwitchResult {
     public static final int STATUS_CANCELED = 2;
     public static final int STATUS_ERROR = 3;
 
-    BrowserSwitchResult(@BrowserSwitchStatus int status) {
-        this(status, null);
-    }
-
     BrowserSwitchResult(@BrowserSwitchStatus int status, String errorMessage) {
         this(status, errorMessage, null);
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
@@ -28,7 +28,7 @@ public class BrowserSwitchResult {
     BrowserSwitchResult(@BrowserSwitchStatus int status, String errorMessage) {
         this(status, errorMessage, null);
     }
-    
+
     BrowserSwitchResult(@BrowserSwitchStatus int status, String errorMessage, JSONObject requestMetadata) {
         this.status = status;
         this.errorMessage = errorMessage;

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchResult.java
@@ -2,6 +2,8 @@ package com.braintreepayments.browserswitch;
 
 import androidx.annotation.IntDef;
 
+import org.json.JSONObject;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -9,6 +11,7 @@ public class BrowserSwitchResult {
 
     final private int status;
     final private String errorMessage;
+    final JSONObject requestMetadata;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({ STATUS_OK, STATUS_CANCELED, STATUS_ERROR })
@@ -23,8 +26,13 @@ public class BrowserSwitchResult {
     }
 
     BrowserSwitchResult(@BrowserSwitchStatus int status, String errorMessage) {
+        this(status, errorMessage, null);
+    }
+    
+    BrowserSwitchResult(@BrowserSwitchStatus int status, String errorMessage, JSONObject requestMetadata) {
         this.status = status;
         this.errorMessage = errorMessage;
+        this.requestMetadata = requestMetadata;
     }
 
     @BrowserSwitchStatus
@@ -34,5 +42,9 @@ public class BrowserSwitchResult {
 
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    public JSONObject getRequestMetadata() {
+        return requestMetadata;
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -471,7 +471,6 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void deliverResult_whenRequestIsSuccessful_clearsResultStoreAndNotifiesResultOK() {
-        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
         when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         JSONObject requestMetadata = new JSONObject();
@@ -480,7 +479,7 @@ public class BrowserSwitchClientTest {
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentAndListener, browserSwitchListener);
+        sut.deliverResult(plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -497,7 +496,6 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void deliverResult_whenRequestIsPending_clearsResultStoreAndNotifiesResultCANCELLED() {
-        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
         when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         JSONObject requestMetadata = new JSONObject();
@@ -506,7 +504,7 @@ public class BrowserSwitchClientTest {
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentAndListener, browserSwitchListener);
+        sut.deliverResult(plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -523,12 +521,11 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void deliverResult_whenRequestIsNull_doesNothing() {
-        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
         when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(null);
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentAndListener, browserSwitchListener);
+        sut.deliverResult(plainActivity, browserSwitchListener);
 
         verify(browserSwitchListener, never()).onBrowserSwitchResult(anyInt(), any(), any());
         verify(persistentStore, never()).clearActiveRequest(plainActivity);
@@ -539,9 +536,8 @@ public class BrowserSwitchClientTest {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
 
-        Fragment fragment = mock(Fragment.class);
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragment);
+        sut.deliverResult(plainFragment);
     }
 
     @Test
@@ -561,6 +557,37 @@ public class BrowserSwitchClientTest {
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
         sut.deliverResult(plainActivity);
+    }
+
+    @Test
+    public void convenience_deliverResultWithActivityListener_forwardsInvocationToPrimaryDeliverResultMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).deliverResult(any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.deliverResult(activityAndListener);
+        verify(sut).deliverResult(activityAndListener, activityAndListener);
+    }
+
+    @Test
+    public void convenience_deliverResultWithFragmentAndExplicitListener_forwardsInvocationToPrimaryDeliverResultMethod() {
+        when(plainFragment.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).deliverResult(any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.deliverResult(plainFragment, browserSwitchListener);
+        verify(sut).deliverResult(plainActivity, browserSwitchListener);
+    }
+
+    @Test
+    public void convenience_deliverResultWithFragmentListener_forwardsInvocationToPrimaryDeliverResultMethod() {
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).deliverResult(any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.deliverResult(fragmentAndListener);
+        verify(sut).deliverResult(plainActivity, fragmentAndListener);
     }
 
     @Test

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +19,7 @@ import org.mockito.Mockito;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -265,8 +267,9 @@ public class BrowserSwitchClientTest {
         when(fragmentListener.getActivity()).thenReturn(activity);
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
+        JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
-            new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.SUCCESS, null);
+            new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.SUCCESS, requestMetadata);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
@@ -280,6 +283,7 @@ public class BrowserSwitchClientTest {
         assertNotNull(result);
         assertEquals(result.getStatus(), BrowserSwitchResult.STATUS_OK);
         assertNull(result.getErrorMessage());
+        assertSame(result.getRequestMetadata(), requestMetadata);
 
         verify(persistentStore).clearActiveRequest(applicationContext);
     }
@@ -289,8 +293,9 @@ public class BrowserSwitchClientTest {
         when(fragmentListener.getActivity()).thenReturn(activity);
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
+        JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
-                new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.PENDING, null);
+                new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.PENDING, requestMetadata);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
@@ -304,6 +309,7 @@ public class BrowserSwitchClientTest {
         assertNotNull(result);
         assertEquals(result.getStatus(), BrowserSwitchResult.STATUS_CANCELED);
         assertNull(result.getErrorMessage());
+        assertSame(result.getRequestMetadata(), requestMetadata);
 
         verify(persistentStore).clearActiveRequest(applicationContext);
     }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -266,7 +266,7 @@ public class BrowserSwitchClientTest {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
         BrowserSwitchRequest request =
-            new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.SUCCESS);
+            new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.SUCCESS, null);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
@@ -290,7 +290,7 @@ public class BrowserSwitchClientTest {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
         BrowserSwitchRequest request =
-                new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.PENDING);
+                new BrowserSwitchRequest(123, uri, BrowserSwitchRequest.PENDING, null);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -90,7 +90,13 @@ public class BrowserSwitchClientTest {
         when(browserSwitchIntent.getData()).thenReturn(uri);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragmentListener, browserSwitchListener);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(uri)
+                .metadata(metadata);
+        sut.start(options, fragmentListener, browserSwitchListener);
 
         verify(applicationContext).startActivity(browserSwitchIntent);
 
@@ -102,6 +108,7 @@ public class BrowserSwitchClientTest {
         assertEquals(browserSwitchRequest.getRequestCode(), 123);
         assertEquals(browserSwitchRequest.getUri(), uri);
         assertEquals(browserSwitchRequest.getState(), BrowserSwitchRequest.PENDING);
+        assertSame(browserSwitchRequest.getMetadata(), metadata);
     }
 
     @Test

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -25,14 +25,17 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class BrowserSwitchClientTest {
 
     static abstract class FragmentListener extends Fragment implements BrowserSwitchListener {}
+    static abstract class ActivityListener extends FragmentActivity implements BrowserSwitchListener {}
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
@@ -43,8 +46,11 @@ public class BrowserSwitchClientTest {
 
     private Uri uri;
 
-    private FragmentListener fragmentListener;
-    private FragmentActivity activity;
+    private Fragment plainFragment;
+    private FragmentActivity plainActivity;
+
+    private ActivityListener activityAndListener;
+    private FragmentListener fragmentAndListener;
 
     private Context applicationContext;
     private BrowserSwitchListener browserSwitchListener;
@@ -60,8 +66,12 @@ public class BrowserSwitchClientTest {
         persistentStore = mock(BrowserSwitchPersistentStore.class);
 
         uri = mock(Uri.class);
-        activity = mock(FragmentActivity.class);
-        fragmentListener = mock(FragmentListener.class);
+
+        plainActivity = mock(FragmentActivity.class);
+        activityAndListener = mock(ActivityListener.class);
+
+        plainFragment = mock(Fragment.class);
+        fragmentAndListener = mock(FragmentListener.class);
 
         applicationContext = mock(Context.class);
         browserSwitchListener = mock(BrowserSwitchListener.class);
@@ -70,22 +80,17 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void start_whenAbleToBrowserSwitch_initiatesBrowserSwitch() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    public void startWithOptionsAndExplicitListener_withUri_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() {
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         Intent queryIntent = mock(Intent.class);
-        when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme))
-                .thenReturn(queryIntent);
+        when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme)).thenReturn(queryIntent);
 
         Intent browserSwitchIntent = mock(Intent.class);
-        when(browserSwitchConfig.createIntentToLaunchUriInBrowser(applicationContext, uri))
-                .thenReturn(browserSwitchIntent);
+        when(browserSwitchConfig.createIntentToLaunchUriInBrowser(applicationContext, uri)).thenReturn(browserSwitchIntent);
 
-        when(activityFinder.canResolveActivityForIntent(applicationContext, queryIntent))
-                .thenReturn(true);
-        when(activityFinder.canResolveActivityForIntent(applicationContext, browserSwitchIntent))
-                .thenReturn(true);
+        when(activityFinder.canResolveActivityForIntent(applicationContext, queryIntent)).thenReturn(true);
+        when(activityFinder.canResolveActivityForIntent(applicationContext, browserSwitchIntent)).thenReturn(true);
 
         when(browserSwitchIntent.getData()).thenReturn(uri);
 
@@ -96,7 +101,42 @@ public class BrowserSwitchClientTest {
                 .requestCode(123)
                 .url(uri)
                 .metadata(metadata);
-        sut.start(options, fragmentListener, browserSwitchListener);
+        sut.start(options, plainActivity, browserSwitchListener);
+
+        verify(applicationContext).startActivity(browserSwitchIntent);
+
+        ArgumentCaptor<BrowserSwitchRequest> captor =
+                ArgumentCaptor.forClass(BrowserSwitchRequest.class);
+        verify(persistentStore).putActiveRequest(captor.capture(), same(applicationContext));
+
+        BrowserSwitchRequest browserSwitchRequest = captor.getValue();
+        assertEquals(browserSwitchRequest.getRequestCode(), 123);
+        assertEquals(browserSwitchRequest.getUri(), uri);
+        assertEquals(browserSwitchRequest.getState(), BrowserSwitchRequest.PENDING);
+        assertSame(browserSwitchRequest.getMetadata(), metadata);
+    }
+
+    @Test
+    public void startWithOptionsAndExplicitListener_withIntent_initiatesBrowserSwitch() {
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
+
+        Intent queryIntent = mock(Intent.class);
+        when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme)).thenReturn(queryIntent);
+
+        Intent browserSwitchIntent = mock(Intent.class);
+        when(activityFinder.canResolveActivityForIntent(applicationContext, queryIntent)).thenReturn(true);
+        when(activityFinder.canResolveActivityForIntent(applicationContext, browserSwitchIntent)).thenReturn(true);
+
+        when(browserSwitchIntent.getData()).thenReturn(uri);
+
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .intent(browserSwitchIntent)
+                .metadata(metadata);
+        sut.start(options, plainActivity, browserSwitchListener);
 
         verify(applicationContext).startActivity(browserSwitchIntent);
 
@@ -112,9 +152,8 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void start_whenRequestCodeIsIntegerMinValue_notifiesListenerOfError() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    public void startWithOptionsAndExplicitListener_whenRequestCodeIsIntegerMinValue_notifiesListenerOfError() {
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         Intent queryIntent = mock(Intent.class);
         when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme))
@@ -136,10 +175,10 @@ public class BrowserSwitchClientTest {
                 .requestCode(Integer.MIN_VALUE)
                 .url(uri)
                 .metadata(metadata);
-        sut.start(options, fragmentListener, browserSwitchListener);
+        sut.start(options, plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
-            ArgumentCaptor.forClass(BrowserSwitchResult.class);
+                ArgumentCaptor.forClass(BrowserSwitchResult.class);
         verify(browserSwitchListener).onBrowserSwitchResult(anyInt(), captor.capture(), isNull());
 
         BrowserSwitchResult result = captor.getValue();
@@ -148,9 +187,8 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void start_whenIsNotConfiguredForBrowserSwitch_notifiesListenerOfError() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    public void startWithOptions_whenIsNotConfiguredForBrowserSwitch_notifiesListenerOfError() {
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         Intent queryIntent = mock(Intent.class);
         when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme))
@@ -172,7 +210,7 @@ public class BrowserSwitchClientTest {
                 .requestCode(123)
                 .url(uri)
                 .metadata(metadata);
-        sut.start(options, fragmentListener, browserSwitchListener);
+        sut.start(options, plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -187,9 +225,8 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void start_whenNoActivityFoundCanOpenURL_notifiesListenerOfError() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    public void startWithOptions_whenNoActivityFoundCanOpenURL_notifiesListenerOfError() {
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         Intent queryIntent = mock(Intent.class);
         when(browserSwitchConfig.createIntentForBrowserSwitchActivityQuery(returnUrlScheme))
@@ -214,7 +251,7 @@ public class BrowserSwitchClientTest {
                 .requestCode(123)
                 .url(uri)
                 .metadata(metadata);
-        sut.start(options, fragmentListener, browserSwitchListener);
+        sut.start(options, plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor = ArgumentCaptor.forClass(BrowserSwitchResult.class);
         verify(browserSwitchListener).onBrowserSwitchResult(eq(123), captor.capture(), isNull());
@@ -225,60 +262,15 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void startWithUri_whenFragmentIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
-
-        Fragment fragment = mock(Fragment.class);
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragment);
-    }
-
-    @Test
-    public void startWithIntent_whenFragmentIsNotABrowserSwitchListener_throwsIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
-
-        Intent intent = mock(Intent.class);
-        Fragment fragment = mock(Fragment.class);
-
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, intent, fragment);
-    }
-
-    @Test
     public void startWithOptions_whenFragmentIsNotABrowserSwitchListener_throwsIllegalArgumentException() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
 
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .requestCode(123);
-        Fragment fragment = mock(Fragment.class);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(browserSwitchOptions, fragment);
-    }
-
-    @Test
-    public void startWithUri_whenFragmentIsNotAttachedToAnActivity_throwsIllegalStateException() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Fragment must be attached to an activity.");
-
-        when(fragmentListener.getActivity()).thenReturn(null);
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragmentListener);
-    }
-
-    @Test
-    public void startWithIntent_whenFragmentIsNotAttachedToAnActivity_throwsIllegalStateException() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Fragment must be attached to an activity.");
-
-        when(fragmentListener.getActivity()).thenReturn(null);
-
-        Intent intent = mock(Intent.class);
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, intent, fragmentListener);
+        sut.start(browserSwitchOptions, plainFragment);
     }
 
     @Test
@@ -286,32 +278,13 @@ public class BrowserSwitchClientTest {
         exceptionRule.expect(IllegalStateException.class);
         exceptionRule.expectMessage("Fragment must be attached to an activity.");
 
-        when(fragmentListener.getActivity()).thenReturn(null);
+        when(fragmentAndListener.getActivity()).thenReturn(null);
 
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .requestCode(123);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(browserSwitchOptions, fragmentListener);
-    }
-
-    @Test
-    public void startWithUri_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
-
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, activity);
-    }
-
-    @Test
-    public void startWithIntent_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
-
-        Intent intent = mock(Intent.class);
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, intent, activity);
+        sut.start(browserSwitchOptions, fragmentAndListener);
     }
 
     @Test
@@ -323,13 +296,183 @@ public class BrowserSwitchClientTest {
                 .requestCode(123);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(browserSwitchOptions, activity);
+        sut.start(browserSwitchOptions, plainActivity);
+    }
+
+    @Test
+    public void convenience_startWithOptionsAndActivityListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions();
+        sut.start(browserSwitchOptions, activityAndListener);
+        verify(sut).start(browserSwitchOptions, activityAndListener, activityAndListener);
+    }
+
+    @Test
+    public void convenience_startWithOptionsAndFragmentListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions();
+        sut.start(browserSwitchOptions, fragmentAndListener);
+        verify(sut).start(browserSwitchOptions, plainActivity, fragmentAndListener);
+    }
+
+    @Test
+    public void convenience_startWithIntentAndActivityAndExplicitListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        Intent browserSwitchIntent = mock(Intent.class);
+        sut.start(123, browserSwitchIntent, plainActivity, browserSwitchListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(browserSwitchListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getIntent(), browserSwitchIntent);
+        assertNull(browserSwitchOptions.getUrl());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithIntentAndActivityListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        Intent browserSwitchIntent = mock(Intent.class);
+        sut.start(123, browserSwitchIntent, activityAndListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(activityAndListener), same(activityAndListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getIntent(), browserSwitchIntent);
+        assertNull(browserSwitchOptions.getUrl());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithIntentAndFragmentAndExplicitListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        when(plainFragment.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        Intent browserSwitchIntent = mock(Intent.class);
+        sut.start(123, browserSwitchIntent, plainFragment, browserSwitchListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(browserSwitchListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getIntent(), browserSwitchIntent);
+        assertNull(browserSwitchOptions.getUrl());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithIntentAndFragmentListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        Intent browserSwitchIntent = mock(Intent.class);
+        sut.start(123, browserSwitchIntent, fragmentAndListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(fragmentAndListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getIntent(), browserSwitchIntent);
+        assertNull(browserSwitchOptions.getUrl());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithUriAndActivityAndExplicitListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.start(123, uri, plainActivity, browserSwitchListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(browserSwitchListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getUrl(), uri);
+        assertNull(browserSwitchOptions.getIntent());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithUriAndActivityListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.start(123, uri, activityAndListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(activityAndListener), same(activityAndListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getUrl(), uri);
+        assertNull(browserSwitchOptions.getIntent());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithUriAndFragmentAndExplicitListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        when(plainFragment.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.start(123, uri, plainFragment, browserSwitchListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(browserSwitchListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getUrl(), uri);
+        assertNull(browserSwitchOptions.getIntent());
+        assertNull(browserSwitchOptions.getMetadata());
+    }
+
+    @Test
+    public void convenience_startWithUriAndFragmentListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+
+        sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
+        doNothing().when(sut).start(any(BrowserSwitchOptions.class), any(FragmentActivity.class), any(BrowserSwitchListener.class));
+
+        sut.start(123, uri, fragmentAndListener);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor = ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+        verify(sut).start(captor.capture(), same(plainActivity), same(fragmentAndListener));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertSame(browserSwitchOptions.getUrl(), uri);
+        assertNull(browserSwitchOptions.getIntent());
+        assertNull(browserSwitchOptions.getMetadata());
     }
 
     @Test
     public void deliverResult_whenRequestIsSuccessful_clearsResultStoreAndNotifiesResultOK() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
@@ -337,7 +480,7 @@ public class BrowserSwitchClientTest {
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentListener, browserSwitchListener);
+        sut.deliverResult(fragmentAndListener, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -354,8 +497,8 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void deliverResult_whenRequestIsPending_clearsResultStoreAndNotifiesResultCANCELLED() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
@@ -363,7 +506,7 @@ public class BrowserSwitchClientTest {
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentListener, browserSwitchListener);
+        sut.deliverResult(fragmentAndListener, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -380,15 +523,15 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void deliverResult_whenRequestIsNull_doesNothing() {
-        when(fragmentListener.getActivity()).thenReturn(activity);
-        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(fragmentAndListener.getActivity()).thenReturn(plainActivity);
+        when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
 
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(null);
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentListener, browserSwitchListener);
+        sut.deliverResult(fragmentAndListener, browserSwitchListener);
 
         verify(browserSwitchListener, never()).onBrowserSwitchResult(anyInt(), any(), any());
-        verify(persistentStore, never()).clearActiveRequest(activity);
+        verify(persistentStore, never()).clearActiveRequest(plainActivity);
     }
 
     @Test
@@ -406,9 +549,9 @@ public class BrowserSwitchClientTest {
         exceptionRule.expect(IllegalStateException.class);
         exceptionRule.expectMessage("Fragment must be attached to an activity.");
 
-        when(fragmentListener.getActivity()).thenReturn(null);
+        when(fragmentAndListener.getActivity()).thenReturn(null);
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(fragmentListener);
+        sut.deliverResult(fragmentAndListener);
     }
 
     @Test
@@ -417,7 +560,7 @@ public class BrowserSwitchClientTest {
         exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.deliverResult(activity);
+        sut.deliverResult(plainActivity);
     }
 
     @Test

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -180,7 +180,7 @@ public class BrowserSwitchClientTest {
         sut.start(options, plainActivity, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
-                ArgumentCaptor.forClass(BrowserSwitchResult.class);
+            ArgumentCaptor.forClass(BrowserSwitchResult.class);
         verify(browserSwitchListener).onBrowserSwitchResult(anyInt(), captor.capture(), isNull());
 
         BrowserSwitchResult result = captor.getValue();

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -130,7 +130,13 @@ public class BrowserSwitchClientTest {
                 .thenReturn(true);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(Integer.MIN_VALUE, uri, fragmentListener, browserSwitchListener);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(Integer.MIN_VALUE)
+                .url(uri)
+                .metadata(metadata);
+        sut.start(options, fragmentListener, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
             ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -160,7 +166,13 @@ public class BrowserSwitchClientTest {
                 .thenReturn(true);
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragmentListener, browserSwitchListener);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(uri)
+                .metadata(metadata);
+        sut.start(options, fragmentListener, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
                 ArgumentCaptor.forClass(BrowserSwitchResult.class);
@@ -196,7 +208,13 @@ public class BrowserSwitchClientTest {
         when(uri.toString()).thenReturn("https://example.com/");
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragmentListener, browserSwitchListener);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(uri)
+                .metadata(metadata);
+        sut.start(options, fragmentListener, browserSwitchListener);
 
         ArgumentCaptor<BrowserSwitchResult> captor = ArgumentCaptor.forClass(BrowserSwitchResult.class);
         verify(browserSwitchListener).onBrowserSwitchResult(eq(123), captor.capture(), isNull());
@@ -217,25 +235,6 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void startWithUri_whenFragmentIsNotAttachedToAnActivity_throwsIllegalStateException() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Fragment must be attached to an activity.");
-
-        when(fragmentListener.getActivity()).thenReturn(null);
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, fragmentListener);
-    }
-
-    @Test
-    public void startWithUri_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
-
-        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
-        sut.start(123, uri, activity);
-    }
-
-    @Test
     public void startWithIntent_whenFragmentIsNotABrowserSwitchListener_throwsIllegalArgumentException() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
@@ -245,6 +244,29 @@ public class BrowserSwitchClientTest {
 
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
         sut.start(123, intent, fragment);
+    }
+
+    @Test
+    public void startWithOptions_whenFragmentIsNotABrowserSwitchListener_throwsIllegalArgumentException() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Fragment must implement BrowserSwitchListener.");
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(123);
+        Fragment fragment = mock(Fragment.class);
+
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+        sut.start(browserSwitchOptions, fragment);
+    }
+
+    @Test
+    public void startWithUri_whenFragmentIsNotAttachedToAnActivity_throwsIllegalStateException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("Fragment must be attached to an activity.");
+
+        when(fragmentListener.getActivity()).thenReturn(null);
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+        sut.start(123, uri, fragmentListener);
     }
 
     @Test
@@ -260,6 +282,29 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
+    public void startWithOptions_whenFragmentIsNotAttachedToAnActivity_throwsIllegalStateException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("Fragment must be attached to an activity.");
+
+        when(fragmentListener.getActivity()).thenReturn(null);
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(123);
+
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+        sut.start(browserSwitchOptions, fragmentListener);
+    }
+
+    @Test
+    public void startWithUri_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
+
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+        sut.start(123, uri, activity);
+    }
+
+    @Test
     public void startWithIntent_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
@@ -267,6 +312,18 @@ public class BrowserSwitchClientTest {
         Intent intent = mock(Intent.class);
         sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
         sut.start(123, intent, activity);
+    }
+
+    @Test
+    public void startWithOptions_whenActivityIsNotBrowserSwitchListener_throwsIllegalArgumentException() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Activity must implement BrowserSwitchListener.");
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(123);
+
+        sut = BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme);
+        sut.start(browserSwitchOptions, activity);
     }
 
     @Test

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -79,6 +79,8 @@ public class BrowserSwitchClientTest {
         returnUrlScheme = "sample-url-scheme";
     }
 
+    //region test startWithOptions
+
     @Test
     public void startWithOptionsAndExplicitListener_withUri_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() {
         when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
@@ -299,6 +301,10 @@ public class BrowserSwitchClientTest {
         sut.start(browserSwitchOptions, plainActivity);
     }
 
+    //endregion
+
+    //region test convenience start methods
+
     @Test
     public void convenience_startWithOptionsAndActivityListener_forwardsInvocationToPrimaryStartWithOptionsMethod() {
         sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
@@ -469,6 +475,10 @@ public class BrowserSwitchClientTest {
         assertNull(browserSwitchOptions.getMetadata());
     }
 
+    //endregion
+
+    //region test deliverResult
+
     @Test
     public void deliverResult_whenRequestIsSuccessful_clearsResultStoreAndNotifiesResultOK() {
         when(plainActivity.getApplicationContext()).thenReturn(applicationContext);
@@ -559,6 +569,10 @@ public class BrowserSwitchClientTest {
         sut.deliverResult(plainActivity);
     }
 
+    //endregion
+
+    //region test convenience deliverResult methods
+
     @Test
     public void convenience_deliverResultWithActivityListener_forwardsInvocationToPrimaryDeliverResultMethod() {
         sut = spy(BrowserSwitchClient.newInstance(browserSwitchConfig, activityFinder, persistentStore, returnUrlScheme));
@@ -589,6 +603,10 @@ public class BrowserSwitchClientTest {
         sut.deliverResult(fragmentAndListener);
         verify(sut).deliverResult(plainActivity, fragmentAndListener);
     }
+
+    //endregion
+
+    //region test captureResult
 
     @Test
     public void captureResult_whenActiveRequestExistsAndIntentHasData_updatesActiveRequestToSuccessState() {
@@ -654,4 +672,6 @@ public class BrowserSwitchClientTest {
         verify(request, never()).setState(any());
         verify(persistentStore, never()).putActiveRequest(any(), any());
     }
+
+    //endregion
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchFragmentTest.java
@@ -8,14 +8,16 @@ import androidx.fragment.app.FragmentManager;
 
 import com.braintreepayments.browserswitch.test.TestBrowserSwitchFragment;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -55,7 +57,7 @@ public class BrowserSwitchFragmentTest {
     @Test
     public void getReturnUrlScheme_returnsUrlSchemeUsingPackageNameFromContext() {
         String result = sut.getReturnUrlScheme();
-        Assert.assertEquals(result, "com.braintreepayments.browserswitch.test.browserswitch");
+        assertEquals(result, "com.braintreepayments.browserswitch.test.browserswitch");
     }
 
     @Test
@@ -64,7 +66,15 @@ public class BrowserSwitchFragmentTest {
         sut.browserSwitch(123, "https://example.com");
 
         Uri uri = Uri.parse("https://example.com");
-        verify(browserSwitchClient).start(123, uri, sut);
+
+        ArgumentCaptor<BrowserSwitchOptions> captor =
+            ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+
+        verify(browserSwitchClient).start(captor.capture(), same(sut));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertEquals(browserSwitchOptions.getUrl(), uri);
     }
 
     @Test
@@ -74,6 +84,23 @@ public class BrowserSwitchFragmentTest {
         sut.browserSwitchClient = browserSwitchClient;
         sut.browserSwitch(123, intent);
 
-        verify(browserSwitchClient).start(123, intent, sut);
+        ArgumentCaptor<BrowserSwitchOptions> captor =
+                ArgumentCaptor.forClass(BrowserSwitchOptions.class);
+
+        verify(browserSwitchClient).start(captor.capture(), same(sut));
+
+        BrowserSwitchOptions browserSwitchOptions = captor.getValue();
+        assertEquals(browserSwitchOptions.getRequestCode(), 123);
+        assertEquals(browserSwitchOptions.getIntent(), intent);
+    }
+
+    @Test
+    public void browserSwitchWithOptions_startsBrowserSwitch() {
+        sut.browserSwitchClient = browserSwitchClient;
+
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions();
+        sut.browserSwitch(browserSwitchOptions);
+
+        verify(browserSwitchClient).start(browserSwitchOptions, sut);
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchPersistentStoreTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchPersistentStoreTest.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.browserswitch;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.junit.Before;
@@ -14,6 +15,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
@@ -21,7 +23,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ PersistentStore.class, BrowserSwitchRequest.class })
+@PrepareForTest({ PersistentStore.class, BrowserSwitchRequest.class, Log.class })
 public class BrowserSwitchPersistentStoreTest {
 
     private Context context;
@@ -29,6 +31,7 @@ public class BrowserSwitchPersistentStoreTest {
 
     @Before
     public void beforeEach() {
+        mockStatic(Log.class);
         mockStatic(PersistentStore.class);
         mockStatic(BrowserSwitchRequest.class);
 

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
@@ -47,7 +47,6 @@ public class BrowserSwitchRequestTest {
 
     @Test
     public void fromJson_withMetadata() throws JSONException {
-
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
@@ -83,4 +82,3 @@ public class BrowserSwitchRequestTest {
         JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
     }
 }
-

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
@@ -1,9 +1,11 @@
 package com.braintreepayments.browserswitch;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.Assert.assertEquals;
 
@@ -16,13 +18,17 @@ public class BrowserSwitchRequestTest {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
-                "  \"state\": \"PENDING\"\n" +
+                "  \"state\": \"PENDING\",\n" +
+                "  \"metadata\": {\n" +
+                "    \"testKey\": \"testValue\"" +
+                "  }" +
                 "}";
         BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
 
         assertEquals(sut.getRequestCode(), 123);
         assertEquals(sut.getUri().toString(), "https://example.com");
         assertEquals(sut.getState(), BrowserSwitchRequest.PENDING);
+        JSONAssert.assertEquals(sut.getMetadata(), new JSONObject().put("testKey", "testValue"), true);
     }
 
     @Test
@@ -30,7 +36,10 @@ public class BrowserSwitchRequestTest {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
-                "  \"state\": \"SUCCESS\"\n" +
+                "  \"state\": \"SUCCESS\",\n" +
+                "  \"metadata\": {\n" +
+                "    \"testKey\": \"testValue\"" +
+                "  }" +
                 "}";
         BrowserSwitchRequest original = BrowserSwitchRequest.fromJson(json);
         BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
@@ -38,5 +47,7 @@ public class BrowserSwitchRequestTest {
         assertEquals(restored.getRequestCode(), original.getRequestCode());
         assertEquals(restored.getUri(), original.getUri());
         assertEquals(restored.getState(), original.getState());
+        JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
     }
 }
+

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchRequestTest.java
@@ -8,12 +8,45 @@ import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class BrowserSwitchRequestTest {
 
     @Test
-    public void fromJson() throws JSONException {
+    public void fromJson_withoutMetadata() throws JSONException {
+
+        String json = "{\n" +
+                "  \"requestCode\": 123,\n" +
+                "  \"url\": \"https://example.com\",\n" +
+                "  \"state\": \"PENDING\"\n" +
+                "}";
+        BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
+
+        assertEquals(sut.getRequestCode(), 123);
+        assertEquals(sut.getUri().toString(), "https://example.com");
+        assertEquals(sut.getState(), BrowserSwitchRequest.PENDING);
+        assertNull(sut.getMetadata());
+    }
+
+    @Test
+    public void toJson_withoutMetadata() throws JSONException {
+        String json = "{\n" +
+                "  \"requestCode\": 123,\n" +
+                "  \"url\": \"https://example.com\",\n" +
+                "  \"state\": \"SUCCESS\"\n" +
+                "}";
+        BrowserSwitchRequest original = BrowserSwitchRequest.fromJson(json);
+        BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
+
+        assertEquals(restored.getRequestCode(), original.getRequestCode());
+        assertEquals(restored.getUri(), original.getUri());
+        assertEquals(restored.getState(), original.getState());
+        assertNull(restored.getMetadata());
+    }
+
+    @Test
+    public void fromJson_withMetadata() throws JSONException {
 
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
@@ -32,7 +65,7 @@ public class BrowserSwitchRequestTest {
     }
 
     @Test
-    public void toJson() throws JSONException {
+    public void toJson_withMetadata() throws JSONException {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -12,6 +12,8 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         versionCode rootProject.versionCode
         versionName rootProject.versionName
+
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     compileOptions {
@@ -25,4 +27,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${rootProject.appCompatVersion}"
     implementation "androidx.annotation:annotation:${rootProject.annotationVersion}"
     implementation "androidx.fragment:fragment:${rootProject.fragmentVersion}"
+
+    androidTestImplementation 'com.lukekorth:device-automator:1.0.0'
 }

--- a/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
@@ -20,7 +20,7 @@ public class BrowserSwitchTest {
     }
 
     @Test(timeout = 60000)
-    public void start() {
+    public void startWithoutMetadata() {
         onDevice(withText("Start Browser Switch")).perform(click());
         onDevice(withText("Red")).waitForExists().perform(click());
 

--- a/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
@@ -1,0 +1,38 @@
+package com.braintreepayments.browserswitch.demo;
+
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.lukekorth.deviceautomator.AutomatorAction.click;
+import static com.lukekorth.deviceautomator.DeviceAutomator.onDevice;
+import static com.lukekorth.deviceautomator.UiObjectMatcher.withText;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class BrowserSwitchTest {
+
+    @Before
+    public void beforeEach() {
+        onDevice().onHomeScreen().launchApp("com.braintreepayments.browserswitch.demo");
+    }
+
+//    @Test(timeout = 60000)
+//    public void start() {
+//        onDevice(withText("Start Browser Switch")).perform(click());
+//    }
+
+    @Test(timeout = 60000)
+    public void startWithMetadata() {
+        onDevice(withText("Start Browser Switch With Metadata")).perform(click());
+        onDevice(withText("Red")).waitForExists().perform(click());
+
+        onDevice(withText("Browser Switch Successful")).waitForExists();
+
+        assertTrue(onDevice(withText("Browser Switch Successful")).exists());
+        assertTrue(onDevice(withText("Selected Color: red")).exists());
+        assertTrue(onDevice(withText("Metadata: testKey=testValue")).exists());
+    }
+}

--- a/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
@@ -19,10 +19,17 @@ public class BrowserSwitchTest {
         onDevice().onHomeScreen().launchApp("com.braintreepayments.browserswitch.demo");
     }
 
-//    @Test(timeout = 60000)
-//    public void start() {
-//        onDevice(withText("Start Browser Switch")).perform(click());
-//    }
+    @Test(timeout = 60000)
+    public void start() {
+        onDevice(withText("Start Browser Switch")).perform(click());
+        onDevice(withText("Red")).waitForExists().perform(click());
+
+        onDevice(withText("Browser Switch Successful")).waitForExists();
+
+        assertTrue(onDevice(withText("Browser Switch Successful")).exists());
+        assertTrue(onDevice(withText("Selected Color: red")).exists());
+        assertTrue(onDevice(withText("Metadata: null")).exists());
+    }
 
     @Test(timeout = 60000)
     public void startWithMetadata() {

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -15,10 +15,14 @@ import com.braintreepayments.browserswitch.BrowserSwitchFragment;
 import com.braintreepayments.browserswitch.BrowserSwitchOptions;
 import com.braintreepayments.browserswitch.BrowserSwitchResult;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class DemoFragment extends BrowserSwitchFragment implements View.OnClickListener {
 
     private TextView mResult;
     private TextView mReturnUrl;
+    private TextView mMetadata;
 
     @Nullable
     @Override
@@ -30,6 +34,7 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
 
         mResult = view.findViewById(R.id.result);
         mReturnUrl = view.findViewById(R.id.return_url);
+        mMetadata = view.findViewById(R.id.metadata);
 
         return view;
     }
@@ -42,10 +47,21 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
                 "://";
 
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .metadata(buildMetadataObject())
                 .requestCode(1)
                 .url(Uri.parse(url));
 
         browserSwitch(browserSwitchOptions);
+    }
+
+    private JSONObject buildMetadataObject() {
+        try {
+            return new JSONObject()
+                    .put("testKey", "testValue");
+        } catch (JSONException ignore) {
+            // do nothing
+        }
+        return null;
     }
 
     @Override
@@ -70,5 +86,10 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
         }
         mResult.setText(resultText);
         mReturnUrl.setText(returnUrl);
+        try {
+            mMetadata.setText(result.getRequestMetadata().getString("testKey"));
+        } catch (JSONException ignore) {
+            // do nothing
+        }
     }
 }

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.braintreepayments.browserswitch.BrowserSwitchFragment;
+import com.braintreepayments.browserswitch.BrowserSwitchOptions;
 import com.braintreepayments.browserswitch.BrowserSwitchResult;
 
 public class DemoFragment extends BrowserSwitchFragment implements View.OnClickListener {
@@ -35,9 +36,13 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
 
     @Override
     public void onClick(View v) {
-        browserSwitch(1, "https://braintree.github.io/popup-bridge-example/" +
-                "this_launches_in_popup.html?popupBridgeReturnUrlPrefix=" + getReturnUrlScheme()
-                + "://");
+        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
+                .requestCode(1)
+                .url("https://braintree.github.io/popup-bridge-example/" +
+                        "this_launches_in_popup.html?popupBridgeReturnUrlPrefix=" + getReturnUrlScheme()
+                        + "://");
+
+        browserSwitch(browserSwitchOptions);
     }
 
     @Override

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -36,11 +36,14 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
 
     @Override
     public void onClick(View v) {
+        String url = "https://braintree.github.io/popup-bridge-example/" +
+                "this_launches_in_popup.html?popupBridgeReturnUrlPrefix=" +
+                getReturnUrlScheme() +
+                "://";
+
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .requestCode(1)
-                .url("https://braintree.github.io/popup-bridge-example/" +
-                        "this_launches_in_popup.html?popupBridgeReturnUrlPrefix=" + getReturnUrlScheme()
-                        + "://");
+                .url(Uri.parse(url));
 
         browserSwitch(browserSwitchOptions);
     }

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoFragment.java
@@ -118,14 +118,16 @@ public class DemoFragment extends BrowserSwitchFragment implements View.OnClickL
         mBrowserSwitchStatusTextView.setText(resultText);
         mSelectedColorTextView.setText(selectedColorText);
 
+        String metadataOutput = null;
         JSONObject requestMetadata = result.getRequestMetadata();
         if (requestMetadata != null) {
             try {
-                String actualValue = result.getRequestMetadata().getString(TEST_KEY);
-                mMetadataTextView.setText(String.format("Metadata: %s=%s", TEST_KEY, actualValue));
+                String metadataValue = result.getRequestMetadata().getString(TEST_KEY);
+                metadataOutput = String.format("%s=%s", TEST_KEY, metadataValue);
             } catch (JSONException ignore) {
                 // do nothing
             }
         }
+        mMetadataTextView.setText(String.format("Metadata: %s", metadataOutput));
     }
 }

--- a/demo/src/main/res/layout/demo_fragment.xml
+++ b/demo/src/main/res/layout/demo_fragment.xml
@@ -1,16 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp">
+    android:layout_margin="16dp"
+    tools:context=".DemoFragment"
+    >
 
     <Button
         android:id="@+id/browser_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/browser_switch_btn_text"
+        />
+
+    <Button
+        android:id="@+id/browser_switch_with_metadata"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/browser_switch_with_metadata_btn_text"
         />
 
     <TextView

--- a/demo/src/main/res/layout/demo_fragment.xml
+++ b/demo/src/main/res/layout/demo_fragment.xml
@@ -24,4 +24,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
+    <TextView
+        android:id="@+id/metadata"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
 </LinearLayout>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="browser_switch_btn_text">Start Browser Switch</string>
+    <string name="browser_switch_with_metadata_btn_text">Start Browser Switch With Metadata</string>
 </resources>


### PR DESCRIPTION

### Summary of changes

 - Create `BrowserSwitchOptions` value object for configuring browser switch behavior
 - Add BrowserSwitchClient#start overloads with `BrowserSwitchOptions` param
 - Add BrowserSwitchFragment#browserSwitch overload with `BrowserSwitchOptions` param

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop @sshropshire 
