### PR TITLE
Use the browser switch with custom tabs in the same activity task as `BraintreeFragment`'s activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # browser-switch-android Release Notes
 
+## TBD
+
+* Use the browser switch with custom tabs in the same activity task as `BraintreeBrowserSwitch`s activity
+* Breaking changes:
+  * The activity which launches the browser switch must now have `android:launchMode="singleTask"`. See the `DemoActivity` entry in the [AndroidManifest.xml](demo/src/main/AndroidManifest.xml) file in the demo application
+  * To ensure that the calling activity will receive the the browser switch result even if the OS kills the app process when the browser is open, you should indicate the activity on app startup. See [DemoApplication](demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoApplication.java) in the demo application:
+    ```java
+    BrowserSwitchActivity.setReturnIntent(new Intent(this, DemoActivity.class))
+    ```
+
 ## 1.1.3
 
 * Update androidx dependencies to latest versions

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchActivity.java
@@ -1,8 +1,10 @@
 package com.braintreepayments.browserswitch;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 /**
@@ -11,6 +13,8 @@ import androidx.annotation.VisibleForTesting;
  * finishes during {@link Activity#onCreate(Bundle)}.
  */
 public class BrowserSwitchActivity extends Activity {
+
+    private static Intent sReturnIntent;
 
     @VisibleForTesting
     // TODO: Refactor browser-switch-android to allow injection of a custom url scheme
@@ -21,6 +25,19 @@ public class BrowserSwitchActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         browserSwitchClient.captureResult(getIntent(), this);
+        if (sReturnIntent != null) {
+            Intent relaunchActivityIntent = new Intent(sReturnIntent)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(relaunchActivityIntent);
+        }
         finish();
+    }
+
+    public static void setReturnIntent(@NonNull Intent returnIntent) {
+        sReturnIntent = returnIntent;
+    }
+
+    public static void clearReturnIntent() {
+        sReturnIntent = null;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -248,7 +248,8 @@ public class BrowserSwitchClient {
             BrowserSwitchRequest request = new BrowserSwitchRequest(
                     requestCode, intent.getData(), BrowserSwitchRequest.PENDING, metadata);
             persistentStore.putActiveRequest(request, appContext);
-            appContext.startActivity(intent);
+            BrowserSwitchActivity.setReturnIntent(activity.getIntent());
+            activity.startActivity(intent);
         } else {
             BrowserSwitchResult result =
                 new BrowserSwitchResult(BrowserSwitchResult.STATUS_ERROR, errorMessage);
@@ -377,6 +378,7 @@ public class BrowserSwitchClient {
                 result = new BrowserSwitchResult(
                         BrowserSwitchResult.STATUS_CANCELED, null, metadata);
             }
+            BrowserSwitchActivity.clearReturnIntent();
             listener.onBrowserSwitchResult(requestCode, result, uri);
         }
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchConfig.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchConfig.java
@@ -12,7 +12,6 @@ class BrowserSwitchConfig {
 
     Intent createIntentToLaunchUriInBrowser(Context context, Uri uri) {
         Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         Context applicationContext = context.getApplicationContext();
         if (ChromeCustomTabs.isAvailable(applicationContext)) {

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -105,7 +105,7 @@ public class BrowserSwitchClientTest {
                 .metadata(metadata);
         sut.start(options, plainActivity, browserSwitchListener);
 
-        verify(applicationContext).startActivity(browserSwitchIntent);
+        verify(plainActivity).startActivity(browserSwitchIntent);
 
         ArgumentCaptor<BrowserSwitchRequest> captor =
                 ArgumentCaptor.forClass(BrowserSwitchRequest.class);
@@ -140,7 +140,7 @@ public class BrowserSwitchClientTest {
                 .metadata(metadata);
         sut.start(options, plainActivity, browserSwitchListener);
 
-        verify(applicationContext).startActivity(browserSwitchIntent);
+        verify(plainActivity).startActivity(browserSwitchIntent);
 
         ArgumentCaptor<BrowserSwitchRequest> captor =
             ArgumentCaptor.forClass(BrowserSwitchRequest.class);

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchConfigTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchConfigTest.java
@@ -54,7 +54,7 @@ public class BrowserSwitchConfigTest {
 
         assertEquals(result.getData().toString(), "https://www.example.com");
         assertEquals(result.getAction(), Intent.ACTION_VIEW);
-        assertEquals(result.getFlags(), Intent.FLAG_ACTIVITY_NEW_TASK);
+        assertEquals(result.getFlags(), 0);
 
         verifyStatic(ChromeCustomTabs.class, never());
         ChromeCustomTabs.addChromeCustomTabsExtras(applicationContext, result);
@@ -70,7 +70,7 @@ public class BrowserSwitchConfigTest {
 
         assertEquals(result.getData().toString(), "https://www.example.com");
         assertEquals(result.getAction(), Intent.ACTION_VIEW);
-        assertEquals(result.getFlags(), Intent.FLAG_ACTIVITY_NEW_TASK);
+        assertEquals(result.getFlags(), 0);
 
         verifyStatic(ChromeCustomTabs.class);
         ChromeCustomTabs.addChromeCustomTabsExtras(applicationContext, result);

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -5,12 +5,14 @@
     >
 
     <application
+        android:name=".DemoApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="Browser Switch Demo"
         android:theme="@style/AppTheme"
         android:allowBackup="false"
         >
-        <activity android:name=".DemoActivity">
+        <activity android:name=".DemoActivity"
+            android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoApplication.java
+++ b/demo/src/main/java/com/braintreepayments/browserswitch/demo/DemoApplication.java
@@ -1,0 +1,19 @@
+package com.braintreepayments.browserswitch.demo;
+
+import android.app.Application;
+import android.content.Intent;
+
+import com.braintreepayments.browserswitch.BrowserSwitchActivity;
+
+public class DemoApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // Edge case: In case our app process was killed when custom tabs was open,
+        // let BrowserSwitchActivity know which activity to relaunch when it finishes.
+        // Android will call its onCreate() with its original intent and extras,
+        // then call its onNewIntent() with this intent without extras.
+        BrowserSwitchActivity.setReturnIntent(
+                new Intent(this, DemoActivity.class));
+    }
+}


### PR DESCRIPTION
### Summary of changes

Motivation:

When 3DS is done in an external browser inside another activity stack, sometimes the users try to navigate back to the app using back or recents:
* Either they navigate back to the app instead of browser after reading their 3DS code (in the sms app or bank app).
* Or, perhaps more rarely, the automatic deep link redirection after a successful code entry doesn't work, and users try to manually navigate back to the app using back or recents, instead of tapping the big blue "RETURN TO APP" button.

These scenarios result in the purchase being canceled.

This PR uses custom tabs in the same activity stack as the app. When the 3DS input succeeds, and the automatic redirection works, the custom tabs are automatically closed, and the calling activity (containing `BrowserSwitchFragment`) is brought to the top of the activity stack.

If the automatic redirection doesn't succeed, we still have the possible problem of a confused user who has to tap on the "RETURN TO APP" button. But since we're in the same activity stack as the app, the user can't navigate away, so the purchase can't be canceled.

Technical details:

* Don't add these flags when launching the browser intent: `FLAG_ACTIVITY_MULTIPLE_TASK`, `FLAG_ACTIVITY_CLEAR_TASK`, `FLAG_ACTIVITY_NEW_TASK`
* Launch the browser from the activity context, not from the application context (we can't use the application context anymore as that requires `FLAG_ACTIVITY_NEW_TASK`)
* Tell `BrowserSwitchActivity` which intent to launch when it finishes (`DemoActivity` in the demo example). This is done in two places:
  - The "normal" scenario is from `BrowserSwitchClient`, just before it launches custom tabs.
  - The other scenario is an edge case, in case the Android OS is aggressively killing our app process (reproducible by toggling "Don't keep activities" and "No background processes" in system developer settings). In this case, the application class tells `BrowserSwitchActivity` which intent to launch.

Note: I tried a few other approaches. For example, using an activity lifecycle callback listener to detect when `BrowserSwitchActivity` finishes, to relaunch `BrowserSwitchFragment`'s activity. These had various issues which can be found in the commit comments of the initial PR #18.

 ### Checklist

 - [x ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- calvarez-ov
