### PR TITLE
Compile for Android 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ sudo: true
 android:
   components:
     - tools
-    - tools
     - platform-tools
     - build-tools-29.0.3
-    - android-28
+    - android-30
 script: ./gradlew --info clean lint test
 after_success: ./deploy_snapshot.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: android
 jdk: oraclejdk8
-notifications:
-  email:
-    - external-ci-notifications+browser-switch-android@getbraintree.com
 sudo: true
 android:
   components:
     - tools
     - platform-tools
-    - build-tools-30.0.0
+    - build-tools-30.0.2
     - android-30
 script: ./gradlew --info clean lint test
-after_success: ./deploy_snapshot.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ android:
     - platform-tools
     - build-tools-30.0.2
     - android-30
+before_install:
+  - yes | sdkmanager "platforms;android-30"
 script: ./gradlew --info clean lint test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-29.0.3
+    - build-tools-30.0.0
     - android-30
 script: ./gradlew --info clean lint test
 after_success: ./deploy_snapshot.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Update to SDK version 30
+* Add `query` section to AndroidManifest to allow querying for web browsers on a device
+
 ## 1.1.1
 
 * Fix bug where `getReturnUrlScheme` is called on BrowserSwitchFragment and an Activity is no longer attached to the fragment
-* Update to SDK version 30
-* Add `query` section to AndroidManifest to allow querying for web browsers on a device
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.1.1
 
 * Fix bug where `getReturnUrlScheme` is called on BrowserSwitchFragment and an Activity is no longer attached to the fragment
+* Update to SDK version 30
+* Add `query` section to AndroidManifest to allow querying for web browsers on a device
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ dependencies {
 }
 ```
 
-To use the latest build from the `master` branch use:
-
- ```groovy
-dependencies {
-  implementation 'com.braintreepayments:browser-switch:1.1.2-SNAPSHOT'
-}
-```
-
 Then, declare `BrowserSwitchActivity` in your `AndroidManifest.xml`:
 
 ```xml

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '29.0.3'
+    buildToolsVersion '30.0.0'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 
-    testImplementation 'org.robolectric:robolectric:4.5-SNAPSHOT'
+    testImplementation 'org.robolectric:robolectric:4.3'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.0'
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:robolectric:4.5-SNAPSHOT'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/browser-switch/src/main/AndroidManifest.xml
+++ b/browser-switch/src/main/AndroidManifest.xml
@@ -1,1 +1,10 @@
-<manifest package="com.braintreepayments.browserswitch" />
+<manifest package="com.braintreepayments.browserswitch"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+</manifest>

--- a/browser-switch/src/test/resources/robolectric.properties
+++ b/browser-switch/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# TODO: remove when Robolectric supports API level 30 (Android 11)
+sdk=28
+

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0-rc01'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }
@@ -34,6 +34,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ plugins {
 
 version '1.1.2-SNAPSHOT'
 ext {
-    compileSdkVersion = 28
+    compileSdkVersion = 30
     minSdkVersion = 21
-    targetSdkVersion = 28
+    targetSdkVersion = 30
     versionCode = 49
     versionName = version
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }
@@ -34,7 +34,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0-rc02'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '29.0.3'
+    buildToolsVersion '30.0.0'
 
     defaultConfig {
         applicationId "com.braintreepayments.browserswitch.demo"

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.0'
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         applicationId "com.braintreepayments.browserswitch.demo"

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -28,5 +28,7 @@ dependencies {
     implementation "androidx.annotation:annotation:${rootProject.annotationVersion}"
     implementation "androidx.fragment:fragment:${rootProject.fragmentVersion}"
 
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestImplementation 'com.lukekorth:device-automator:1.0.0'
 }

--- a/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/browserswitch/demo/BrowserSwitchTest.java
@@ -1,22 +1,48 @@
 package com.braintreepayments.browserswitch.demo;
 
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static androidx.test.uiautomator.Until.hasObject;
 import static com.lukekorth.deviceautomator.AutomatorAction.click;
 import static com.lukekorth.deviceautomator.DeviceAutomator.onDevice;
 import static com.lukekorth.deviceautomator.UiObjectMatcher.withText;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(AndroidJUnit4ClassRunner.class)
 public class BrowserSwitchTest {
 
     @Before
     public void beforeEach() {
-        onDevice().onHomeScreen().launchApp("com.braintreepayments.browserswitch.demo");
+        // TODO: update device automator to use ApplicationProvider and new androidx testing libraries
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        UiDevice device = UiDevice.getInstance(instrumentation);
+        device.pressHome();
+
+        String launcherPackage = device.getLauncherPackageName();
+        device.wait(hasObject(By.pkg(launcherPackage).depth(0)), 5000);
+
+        String packageName = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageName();
+
+        Context context = ApplicationProvider.getApplicationContext();
+        Intent intent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        context.startActivity(intent);
+
+        device.wait(hasObject(By.pkg(intent.getPackage()).depth(0)), 5000);
     }
 
     @Test(timeout = 60000)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 17 11:18:09 CDT 2020
+#Wed Sep 02 14:59:36 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 23 11:15:05 CDT 2020
+#Mon Aug 17 11:18:09 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
### Summary of changes

 - Update to SDK version 30
 - Add `query` section to AndroidManifest to allow querying for web browsers on a device
 - Eliminate snapshot builds

 ### Checklist

 - [x] Added a changelog entry

### Authors
- @sarahkoop 
- @sshropshire 