### PR TITLE
Fix BrowserSwitchFragment Null Pointer in `getReturnUrlScheme` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # browser-switch-android Release Notes
 
+## unreleased
+* Fix bug where `getReturnUrlScheme` is called on BrowserSwitchFragment and an Activity is no longer attached to the fragment
+
 ## 1.1.0
 
 * Create `BrowserSwitchOptions` value object for configuring browser switch behavior

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -1,9 +1,11 @@
 package com.braintreepayments.browserswitch;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
@@ -20,16 +22,17 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
     private String returnUrlScheme;
 
     @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        String packageName = context.getApplicationContext().getPackageName();
+        returnUrlScheme =
+                packageName.toLowerCase().replace("_", "") + ".browserswitch";
+    }
+
+    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         browserSwitchClient = BrowserSwitchClient.newInstance(getReturnUrlScheme());
-
-        FragmentActivity activity = getActivity();
-        if (activity != null) {
-            String packageName = activity.getApplicationContext().getPackageName();
-            returnUrlScheme =
-                packageName.toLowerCase().replace("_", "") + ".browserswitch";
-        }
     }
 
     @Override

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
 
 /**
  * Abstract Fragment that manages the logic for browser switching.
@@ -46,7 +45,6 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
      * scheme should be used to build a return url and passed to the target web page via a query
      * param when browser switching.
      */
-    @SuppressWarnings("WeakerAccess")
     public String getReturnUrlScheme() {
         return returnUrlScheme;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchFragment.java
@@ -17,10 +17,19 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
     @VisibleForTesting
     BrowserSwitchClient browserSwitchClient = null;
 
+    private String returnUrlScheme;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         browserSwitchClient = BrowserSwitchClient.newInstance(getReturnUrlScheme());
+
+        FragmentActivity activity = getActivity();
+        if (activity != null) {
+            String packageName = activity.getApplicationContext().getPackageName();
+            returnUrlScheme =
+                packageName.toLowerCase().replace("_", "") + ".browserswitch";
+        }
     }
 
     @Override
@@ -36,12 +45,7 @@ public abstract class BrowserSwitchFragment extends Fragment implements BrowserS
      */
     @SuppressWarnings("WeakerAccess")
     public String getReturnUrlScheme() {
-        FragmentActivity activity = getActivity();
-        if (activity != null) {
-            String packageName = activity.getApplicationContext().getPackageName();
-            return packageName.toLowerCase().replace("_", "") + ".browserswitch";
-        }
-        return null;
+        return returnUrlScheme;
     }
 
     /**


### PR DESCRIPTION
### Summary of changes

 - Fix BrowserSwitchFragment NPE when `getReturnUrlScheme` is called and an Activity is no longer attached to the fragment.

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
- @sshropshire