### PR TITLE
Move BrowserSwitch to com.braintreepayments.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `returnUrlScheme` to `BrowserSwitchOptions`
 * Add `requestCode`, `requestUri` and `deepLinkUri` properties to `BrowserSwitchResult`
 * Breaking Changes
+  * Move BrowserSwitch module from `com.braintreepayments.browserswitch` package to `com.braintreepayments.api`
   * Remove `BrowserSwitchFragment`
   * Remove `BrowserSwitchActivity`
   * Remove convenience `start` methods

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Add the library to your dependencies in your `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'com.braintreepayments:browser-switch:1.1.3'
+  implementation 'com.braintreepayments.api:browser-switch:1.1.3'
 }
 ```
 
 Then, declare `BrowserSwitchActivity` in your `AndroidManifest.xml`:
 
 ```xml
-<activity android:name="com.braintreepayments.browserswitch.BrowserSwitchActivity"
+<activity android:name="com.braintreepayments.api.BrowserSwitchActivity"
     android:launchMode="singleTask">
     <intent-filter>
         <action android:name="android.intent.action.VIEW"/>

--- a/browser-switch/src/main/AndroidManifest.xml
+++ b/browser-switch/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest package="com.braintreepayments.browserswitch"
+<manifest package="com.braintreepayments.api.browserswitch"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <intent>

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.Intent;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchException.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchException.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 public class BrowserSwitchException extends Exception {
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.Intent;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 public interface BrowserSwitchListener {
     /**

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.net.Uri;
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.util.Log;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.net.Uri;
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.net.Uri;
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/PersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/PersistentStore.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.Intent;

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchInspectorUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchInspectorUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.Intent;

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPersistentStoreUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPersistentStoreUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.util.Log;
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static com.braintreepayments.browserswitch.BrowserSwitchPersistentStore.REQUEST_KEY;
+import static com.braintreepayments.api.BrowserSwitchPersistentStore.REQUEST_KEY;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.any;

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/browser-switch/src/test/java/com/braintreepayments/api/PersistentStoreUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/PersistentStoreUnitTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch;
+package com.braintreepayments.api;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -11,7 +11,7 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static com.braintreepayments.browserswitch.PersistentStore.PREFERENCES_KEY;
+import static com.braintreepayments.api.PersistentStore.PREFERENCES_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;

--- a/demo/src/androidTest/java/com/braintreepayments/api/demo/BrowserSwitchTest.java
+++ b/demo/src/androidTest/java/com/braintreepayments/api/demo/BrowserSwitchTest.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch.demo;
+package com.braintreepayments.api.demo;
 
 import android.app.Instrumentation;
 import android.content.Context;

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.braintreepayments.browserswitch.demo">
+    package="com.braintreepayments.api.demo">
 
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="Browser Switch Demo"
         android:theme="@style/AppTheme">
-        <activity android:name="com.braintreepayments.browserswitch.demo.DemoActivity">
+        <activity android:name="com.braintreepayments.api.demo.DemoActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch.demo;
+package com.braintreepayments.api.demo;
 
 import android.os.Bundle;
 

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -1,4 +1,4 @@
-package com.braintreepayments.browserswitch.demo;
+package com.braintreepayments.api.demo;
 
 import android.net.Uri;
 import android.os.Bundle;
@@ -13,11 +13,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 
-import com.braintreepayments.browserswitch.BrowserSwitchClient;
-import com.braintreepayments.browserswitch.BrowserSwitchException;
-import com.braintreepayments.browserswitch.BrowserSwitchListener;
-import com.braintreepayments.browserswitch.BrowserSwitchOptions;
-import com.braintreepayments.browserswitch.BrowserSwitchResult;
+import com.braintreepayments.api.BrowserSwitchClient;
+import com.braintreepayments.api.BrowserSwitchException;
+import com.braintreepayments.api.BrowserSwitchListener;
+import com.braintreepayments.api.BrowserSwitchOptions;
+import com.braintreepayments.api.BrowserSwitchResult;
 
 import org.json.JSONException;
 import org.json.JSONObject;


### PR DESCRIPTION
### Summary of changes

 -   * Move BrowserSwitch module from `com.braintreepayments.browserswitch` package to `com.braintreepayments.api` 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @sshropshire 
