### PR TITLE
Rename Uri Variables to Url

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -119,11 +119,11 @@ public class BrowserSwitchClient {
 
         BrowserSwitchResult result;
 
-        Uri deepLinkUri = intent.getData();
-        if (deepLinkUri == null) {
+        Uri deepLinkUrl = intent.getData();
+        if (deepLinkUrl == null) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
         } else {
-            result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUri);
+            result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
         }
 
         // ensure that browser switch result is delivered exactly one time

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
@@ -15,8 +15,8 @@ class BrowserSwitchInspector {
         return canResolveActivityForIntent(context, deepLinkIntent);
     }
 
-    boolean canDeviceOpenUrl(Context context, Uri uri) {
-        Intent browserSwitchIntent = new Intent(Intent.ACTION_VIEW, uri);
+    boolean canDeviceOpenUrl(Context context, Uri url) {
+        Intent browserSwitchIntent = new Intent(Intent.ACTION_VIEW, url);
         return canResolveActivityForIntent(context, browserSwitchIntent);
     }
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -7,7 +7,7 @@ import org.json.JSONObject;
 
 class BrowserSwitchRequest {
 
-    private final Uri uri;
+    private final Uri url;
     private final int requestCode;
     private final JSONObject metadata;
 
@@ -19,14 +19,14 @@ class BrowserSwitchRequest {
         return new BrowserSwitchRequest(requestCode, Uri.parse(url), metadata);
     }
 
-    BrowserSwitchRequest(int requestCode, Uri uri, JSONObject metadata) {
-        this.uri = uri;
+    BrowserSwitchRequest(int requestCode, Uri url, JSONObject metadata) {
+        this.url = url;
         this.requestCode = requestCode;
         this.metadata = metadata;
     }
 
-    Uri getUri() {
-        return uri;
+    Uri getUrl() {
+        return url;
     }
 
     int getRequestCode() {
@@ -40,7 +40,7 @@ class BrowserSwitchRequest {
     String toJson() throws JSONException {
         JSONObject result = new JSONObject();
         result.put("requestCode", requestCode);
-        result.put("url", uri.toString());
+        result.put("url", url.toString());
         if (metadata != null) {
             result.put("metadata", metadata);
         }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
@@ -48,7 +48,6 @@ public class BrowserSwitchResult {
         return request.getRequestCode();
     }
 
-    // TODO: Make url and uri variable and method naming consistent
     /**
      * @return The target url used to initiate the browser switch
      */

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
@@ -2,13 +2,9 @@ package com.braintreepayments.api;
 
 import android.net.Uri;
 
-import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 
 import org.json.JSONObject;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 /**
  * The result of the browser switch.
@@ -16,17 +12,17 @@ import java.lang.annotation.RetentionPolicy;
 public class BrowserSwitchResult {
 
     private final int status;
-    private final Uri deepLinkUri;
+    private final Uri deepLinkUrl;
     private final BrowserSwitchRequest request;
 
     BrowserSwitchResult(@BrowserSwitchStatus int status, BrowserSwitchRequest request) {
         this(status, request, null);
     }
 
-    BrowserSwitchResult(@BrowserSwitchStatus int status, BrowserSwitchRequest request, Uri deepLinkUri) {
+    BrowserSwitchResult(@BrowserSwitchStatus int status, BrowserSwitchRequest request, Uri deepLinkUrl) {
         this.status = status;
         this.request = request;
-        this.deepLinkUri = deepLinkUri;
+        this.deepLinkUrl = deepLinkUrl;
     }
 
     /**
@@ -58,7 +54,7 @@ public class BrowserSwitchResult {
      */
     @Nullable
     public Uri getRequestUrl() {
-        return request.getUri();
+        return request.getUrl();
     }
 
     /**
@@ -66,6 +62,6 @@ public class BrowserSwitchResult {
      */
     @Nullable
     public Uri getDeepLinkUrl() {
-        return deepLinkUri;
+        return deepLinkUrl;
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
@@ -34,7 +34,7 @@ public class BrowserSwitchClientTest {
     private BrowserSwitchInspector browserSwitchInspector;
     private CustomTabsIntent.Builder customTabsIntentBuilder;
 
-    private Uri uri;
+    private Uri url;
     private Context applicationContext;
 
     private FragmentActivity activity;
@@ -48,7 +48,7 @@ public class BrowserSwitchClientTest {
         browserSwitchInspector = mock(BrowserSwitchInspector.class);
         customTabsIntentBuilder = mock(CustomTabsIntent.Builder.class);
 
-        uri = mock(Uri.class);
+        url = mock(Uri.class);
 
         activity = mock(FragmentActivity.class);
         applicationContext = mock(Context.class);
@@ -62,7 +62,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() throws BrowserSwitchException {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, uri)).thenReturn(true);
+        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, url)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, returnUrlScheme)).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
@@ -70,12 +70,12 @@ public class BrowserSwitchClientTest {
         JSONObject metadata = new JSONObject();
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(123)
-                .url(uri)
+                .url(url)
                 .returnUrlScheme(returnUrlScheme)
                 .metadata(metadata);
         sut.start(activity, options);
 
-        verify(customTabsIntent).launchUrl(activity, uri);
+        verify(customTabsIntent).launchUrl(activity, url);
 
         ArgumentCaptor<BrowserSwitchRequest> captor =
                 ArgumentCaptor.forClass(BrowserSwitchRequest.class);
@@ -83,13 +83,13 @@ public class BrowserSwitchClientTest {
 
         BrowserSwitchRequest browserSwitchRequest = captor.getValue();
         assertEquals(browserSwitchRequest.getRequestCode(), 123);
-        assertEquals(browserSwitchRequest.getUri(), uri);
+        assertEquals(browserSwitchRequest.getUrl(), url);
         assertSame(browserSwitchRequest.getMetadata(), metadata);
     }
 
     @Test
     public void start_whenRequestCodeIsIntegerMinValue_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, uri)).thenReturn(true);
+        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, url)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, returnUrlScheme)).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
@@ -97,7 +97,7 @@ public class BrowserSwitchClientTest {
         JSONObject metadata = new JSONObject();
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(Integer.MIN_VALUE)
-                .url(uri)
+                .url(url)
                 .returnUrlScheme(returnUrlScheme)
                 .metadata(metadata);
         try {
@@ -110,7 +110,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenDeviceIsNotConfiguredForDeepLinking_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, uri)).thenReturn(true);
+        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, url)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, returnUrlScheme)).thenReturn(false);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
@@ -118,7 +118,7 @@ public class BrowserSwitchClientTest {
         JSONObject metadata = new JSONObject();
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(123)
-                .url(uri)
+                .url(url)
                 .returnUrlScheme(returnUrlScheme)
                 .metadata(metadata);
 
@@ -135,17 +135,17 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenNoActivityFoundCanOpenURL_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, uri)).thenReturn(false);
+        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, url)).thenReturn(false);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, returnUrlScheme)).thenReturn(true);
 
-        when(uri.toString()).thenReturn("https://example.com/");
+        when(url.toString()).thenReturn("https://example.com/");
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
 
         JSONObject metadata = new JSONObject();
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(123)
-                .url(uri)
+                .url(url)
                 .returnUrlScheme(returnUrlScheme)
                 .metadata(metadata);
         try {
@@ -158,10 +158,10 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenNoReturnUrlSchemeSet_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, uri)).thenReturn(true);
+        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, url)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, returnUrlScheme)).thenReturn(true);
 
-        when(uri.toString()).thenReturn("https://example.com/");
+        when(url.toString()).thenReturn("https://example.com/");
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
 
@@ -169,7 +169,7 @@ public class BrowserSwitchClientTest {
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(123)
                 .returnUrlScheme(null)
-                .url(uri)
+                .url(url)
                 .metadata(metadata);
         try {
             sut.start(activity, options);
@@ -183,15 +183,15 @@ public class BrowserSwitchClientTest {
     public void deliverResult_whenRequestIsSuccessful_clearsResultStoreAndNotifiesResultOK() {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
-        Uri deepLinkUri = mock(Uri.class);
+        Uri deepLinkUrl = mock(Uri.class);
         Intent deepLinkIntent = mock(Intent.class);
-        when(deepLinkIntent.getData()).thenReturn(deepLinkUri);
+        when(deepLinkIntent.getData()).thenReturn(deepLinkUrl);
 
         when(activity.getIntent()).thenReturn(deepLinkIntent);
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
-            new BrowserSwitchRequest(123, uri, requestMetadata);
+            new BrowserSwitchRequest(123, url, requestMetadata);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
@@ -199,10 +199,10 @@ public class BrowserSwitchClientTest {
 
         assertNotNull(result);
         assertEquals(123, result.getRequestCode());
-        assertSame(uri, result.getRequestUrl());
+        assertSame(url, result.getRequestUrl());
         assertEquals(BrowserSwitchStatus.SUCCESS, result.getStatus());
         assertSame(requestMetadata, result.getRequestMetadata());
-        assertSame(deepLinkUri, result.getDeepLinkUrl());
+        assertSame(deepLinkUrl, result.getDeepLinkUrl());
 
         verify(persistentStore).clearActiveRequest(applicationContext);
     }
@@ -214,7 +214,7 @@ public class BrowserSwitchClientTest {
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
-                new BrowserSwitchRequest(123, uri, requestMetadata);
+                new BrowserSwitchRequest(123, url, requestMetadata);
         when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsIntentBuilder);
@@ -222,7 +222,7 @@ public class BrowserSwitchClientTest {
 
         assertNotNull(result);
         assertEquals(123, result.getRequestCode());
-        assertSame(uri, result.getRequestUrl());
+        assertSame(url, result.getRequestUrl());
         assertEquals(result.getStatus(), BrowserSwitchStatus.CANCELED);
         assertSame(result.getRequestMetadata(), requestMetadata);
         assertNull(result.getDeepLinkUrl());

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -23,7 +23,7 @@ public class BrowserSwitchRequestUnitTest {
         BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
 
         assertEquals(sut.getRequestCode(), 123);
-        assertEquals(sut.getUri().toString(), "https://example.com");
+        assertEquals(sut.getUrl().toString(), "https://example.com");
         assertNull(sut.getMetadata());
     }
 
@@ -37,7 +37,7 @@ public class BrowserSwitchRequestUnitTest {
         BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
 
         assertEquals(restored.getRequestCode(), original.getRequestCode());
-        assertEquals(restored.getUri(), original.getUri());
+        assertEquals(restored.getUrl(), original.getUrl());
         assertNull(restored.getMetadata());
     }
 
@@ -53,7 +53,7 @@ public class BrowserSwitchRequestUnitTest {
         BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
 
         assertEquals(sut.getRequestCode(), 123);
-        assertEquals(sut.getUri().toString(), "https://example.com");
+        assertEquals(sut.getUrl().toString(), "https://example.com");
         JSONAssert.assertEquals(sut.getMetadata(), new JSONObject().put("testKey", "testValue"), true);
     }
 
@@ -70,7 +70,7 @@ public class BrowserSwitchRequestUnitTest {
         BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
 
         assertEquals(restored.getRequestCode(), original.getRequestCode());
-        assertEquals(restored.getUri(), original.getUri());
+        assertEquals(restored.getUrl(), original.getUrl());
         JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
     }
 }

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -117,9 +117,9 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
             case BrowserSwitchStatus.SUCCESS:
                 resultText = "Browser Switch Successful";
 
-                Uri returnUri = result.getDeepLinkUrl();
-                if (returnUri != null) {
-                    String color = returnUri.getQueryParameter("color");
+                Uri returnUrl = result.getDeepLinkUrl();
+                if (returnUrl != null) {
+                    String color = returnUrl.getQueryParameter("color");
                     selectedColorText = String.format("Selected color: %s", color);
                 }
                 break;


### PR DESCRIPTION
### Summary of changes

 - Rename internal variables including `uri` to `url` for consistency and to match public accessor methods

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
