### PR TITLE
Add SourcesJar and JavadocsJar to Maven Publish

### DIFF
--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -71,11 +71,6 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-artifacts {
-    archives javadocsJar
-    archives sourcesJar
-}
-
 signing {
     required {
         !version.endsWith("SNAPSHOT") && !version.endsWith("DEVELOPMENT")
@@ -97,6 +92,9 @@ afterEvaluate {
             release(MavenPublication) {
                 // Applies the component for the release build variant.
                 from components.release
+
+                artifact sourcesJar
+                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'browser-switch'


### PR DESCRIPTION
### Summary of changes

 - Fix an issue that caused javadocs and source jars to be omitted from `maven-publish` artifacts

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @sshropshire