### PR TITLE
Add deviceHasBrowser Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Fix issue where app links couldn't be opened by `BrowserSwitchClient#start()`
+
 ## 2.0.0-beta2
 
 * Fix issue of false successful result when `deepLinkUrl` did not match request `returnUrlScheme`

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -6,7 +6,6 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.fragment.app.FragmentActivity;
 
 import org.json.JSONObject;
@@ -79,7 +78,7 @@ public class BrowserSwitchClient {
                 "scheme in it's Android Manifest. See " +
                 "https://github.com/braintree/browser-switch-android for more " +
                 "information on setting up a return url scheme.";
-        } else if (!browserSwitchInspector.canDeviceOpenUrl(appContext, browserSwitchUrl)) {
+        } else if (!browserSwitchInspector.deviceHasBrowser(appContext)) {
             StringBuilder messageBuilder = new StringBuilder("No installed activities can open this URL");
             if (browserSwitchUrl != null) {
                 messageBuilder.append(String.format(": %s", browserSwitchUrl.toString()));

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchInspector.java
@@ -15,8 +15,8 @@ class BrowserSwitchInspector {
         return canResolveActivityForIntent(context, deepLinkIntent);
     }
 
-    boolean canDeviceOpenUrl(Context context, Uri url) {
-        Intent browserSwitchIntent = new Intent(Intent.ACTION_VIEW, url);
+    boolean deviceHasBrowser(Context context) {
+        Intent browserSwitchIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://"));
         return canResolveActivityForIntent(context, browserSwitchIntent);
     }
 

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
@@ -59,7 +59,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() throws BrowserSwitchException {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, browserSwitchDestinationUrl)).thenReturn(true);
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
@@ -86,7 +86,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenRequestCodeIsIntegerMinValue_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, browserSwitchDestinationUrl)).thenReturn(true);
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
@@ -107,7 +107,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenDeviceIsNotConfiguredForDeepLinking_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, browserSwitchDestinationUrl)).thenReturn(true);
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(false);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
@@ -132,7 +132,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenNoActivityFoundCanOpenURL_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, browserSwitchDestinationUrl)).thenReturn(false);
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(false);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
@@ -153,7 +153,7 @@ public class BrowserSwitchClientTest {
 
     @Test
     public void start_whenNoReturnUrlSchemeSet_throwsError() {
-        when(browserSwitchInspector.canDeviceOpenUrl(applicationContext, browserSwitchDestinationUrl)).thenReturn(true);
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchInspectorUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchInspectorUnitTest.java
@@ -83,38 +83,38 @@ public class BrowserSwitchInspectorUnitTest extends TestCase {
     }
 
     @Test
-    public void canDeviceOpenUrl_queriesPackageManagerForIntentForBrowserSwitching() {
+    public void deviceHasBrowser_queriesPackageManagerForIntentForBrowserSwitching() {
         when(context.getPackageManager()).thenReturn(packageManager);
         when(packageManager.queryIntentActivities(any(Intent.class), eq(0))).thenReturn(Collections.emptyList());
 
         BrowserSwitchInspector sut = new BrowserSwitchInspector();
-        sut.canDeviceOpenUrl(context, Uri.parse("https://example.com"));
+        sut.deviceHasBrowser(context);
 
         ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
         verify(packageManager).queryIntentActivities(captor.capture(), eq(0));
 
         Intent intent = captor.getValue();
         assertEquals(Intent.ACTION_VIEW, intent.getAction());
-        assertEquals(Uri.parse("https://example.com"), intent.getData());
+        assertEquals(Uri.parse("https://"), intent.getData());
     }
 
     @Test
-    public void canDeviceOpenUrl_whenNoActivityFound_returnsFalse() {
+    public void deviceHasBrowser_whenNoActivityFound_returnsFalse() {
         when(context.getPackageManager()).thenReturn(packageManager);
         when(packageManager.queryIntentActivities(any(Intent.class), eq(0))).thenReturn(Collections.emptyList());
 
         BrowserSwitchInspector sut = new BrowserSwitchInspector();
-        assertFalse(sut.canDeviceOpenUrl(context, Uri.parse("https://example.com")));
+        assertFalse(sut.deviceHasBrowser(context));
     }
 
     @Test
-    public void canDeviceOpenUrl_whenActivityFound_returnsTrue() {
+    public void deviceHasBrowser_whenActivityFound_returnsTrue() {
         when(context.getPackageManager()).thenReturn(packageManager);
 
         ResolveInfo resolveInfo = mock(ResolveInfo.class);
         when(packageManager.queryIntentActivities(any(Intent.class), eq(0))).thenReturn(Collections.singletonList(resolveInfo));
 
         BrowserSwitchInspector sut = new BrowserSwitchInspector();
-        assertTrue(sut.canDeviceOpenUrl(context, Uri.parse("https://example.com")));
+        assertTrue(sut.deviceHasBrowser(context));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Change `canDeviceOpenUrl` method to `deviceHasBrowser` to fix an issue where app links couldn't be opened

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 
