### PR TITLE
Add deviceHasBrowser Check v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Fix issue where app links couldn't be opened by `BrowserSwitchClient#start()`
+
 ## 1.1.3
 
 * Update androidx dependencies to latest versions

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/ActivityFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/ActivityFinder.java
@@ -2,6 +2,7 @@ package com.braintreepayments.browserswitch;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 class ActivityFinder {
 
@@ -13,5 +14,10 @@ class ActivityFinder {
 
     boolean canResolveActivityForIntent(Context context, Intent intent) {
         return !context.getPackageManager().queryIntentActivities(intent, 0).isEmpty();
+    }
+
+    boolean deviceHasBrowser(Context context) {
+        Intent browserSwitchIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://"));
+        return canResolveActivityForIntent(context, browserSwitchIntent);
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/browserswitch/BrowserSwitchClient.java
@@ -268,7 +268,7 @@ public class BrowserSwitchClient {
                 "scheme in it's Android Manifest. See " +
                 "https://github.com/braintree/browser-switch-android for more " +
                 "information on setting up a return url scheme.";
-        } else if (!canOpenUrl(context, intent)) {
+        } else if (!deviceHasBrowser(context)) {
             StringBuilder messageBuilder = new StringBuilder("No installed activities can open this URL");
             Uri uri = intent.getData();
             if (uri != null) {
@@ -290,8 +290,8 @@ public class BrowserSwitchClient {
         return activityFinder.canResolveActivityForIntent(context, browserSwitchActivityIntent);
     }
 
-    private boolean canOpenUrl(Context context, Intent intent) {
-        return activityFinder.canResolveActivityForIntent(context, intent);
+    private boolean deviceHasBrowser(Context context) {
+        return activityFinder.deviceHasBrowser(context);
     }
 
     /**

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/ActivityFinderTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/ActivityFinderTest.java
@@ -4,17 +4,26 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.net.Uri;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.Collections;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
 public class ActivityFinderTest {
 
     private Intent intent;
@@ -48,5 +57,37 @@ public class ActivityFinderTest {
 
         ActivityFinder sut = ActivityFinder.newInstance();
         assertTrue(sut.canResolveActivityForIntent(context, intent));
+    }
+
+    @Test
+    public void deviceHasBrowser_whenNoActivityFound_returnsFalse() {
+        when(context.getPackageManager()).thenReturn(packageManager);
+        when(packageManager.queryIntentActivities(any(Intent.class), eq(0))).thenReturn(Collections.emptyList());
+
+        ActivityFinder sut = ActivityFinder.newInstance();
+        assertFalse(sut.deviceHasBrowser(context));
+
+        ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
+        verify(packageManager).queryIntentActivities(captor.capture(), eq(0));
+
+        Intent intent = captor.getValue();
+        assertEquals(Uri.parse("https://"), intent.getData());
+    }
+
+    @Test
+    public void deviceHasBrowser_whenActivityFound_returnsTrue() {
+        when(context.getPackageManager()).thenReturn(packageManager);
+
+        ResolveInfo resolveInfo = mock(ResolveInfo.class);
+        when(packageManager.queryIntentActivities(any(Intent.class), eq(0))).thenReturn(Collections.singletonList(resolveInfo));
+
+        ActivityFinder sut = ActivityFinder.newInstance();
+        assertTrue(sut.deviceHasBrowser(context));
+
+        ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
+        verify(packageManager).queryIntentActivities(captor.capture(), eq(0));
+
+        Intent intent = captor.getValue();
+        assertEquals(Uri.parse("https://"), intent.getData());
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/browserswitch/BrowserSwitchClientTest.java
@@ -92,7 +92,7 @@ public class BrowserSwitchClientTest {
         when(browserSwitchConfig.createIntentToLaunchUriInBrowser(applicationContext, uri)).thenReturn(browserSwitchIntent);
 
         when(activityFinder.canResolveActivityForIntent(applicationContext, queryIntent)).thenReturn(true);
-        when(activityFinder.canResolveActivityForIntent(applicationContext, browserSwitchIntent)).thenReturn(true);
+        when(activityFinder.deviceHasBrowser(applicationContext)).thenReturn(true);
 
         when(browserSwitchIntent.getData()).thenReturn(uri);
 
@@ -127,7 +127,7 @@ public class BrowserSwitchClientTest {
 
         Intent browserSwitchIntent = mock(Intent.class);
         when(activityFinder.canResolveActivityForIntent(applicationContext, queryIntent)).thenReturn(true);
-        when(activityFinder.canResolveActivityForIntent(applicationContext, browserSwitchIntent)).thenReturn(true);
+        when(activityFinder.deviceHasBrowser(applicationContext)).thenReturn(true);
 
         when(browserSwitchIntent.getData()).thenReturn(uri);
 


### PR DESCRIPTION
### Summary of changes

- Change `canOpenUrl` method to `deviceHasBrowser` to fix an issue where app links couldn't be opened

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
- @sarahkoop 
