### PR TITLE
BrowserSwitchRequest Should Notify Cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## unreleased
 
-* Fix nullability annotations in `BrowserSwitchOptions` setters 
 * Update `BrowserSwitchClient#deliverResult()` to allow canceled browser switches a chance to reach the success state (See braintree_android [#409](https://github.com/braintree/braintree_android/issues/409))
+* Fix nullability annotations in `BrowserSwitchOptions` setters 
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Fix nullability annotations in `BrowserSwitchOptions` setters 
+* Update `BrowserSwitchClient#deliverResult()` to allow canceled browser switches a chance to reach the success state (See braintree_android [#409](https://github.com/braintree/braintree_android/issues/409))
 
 ## 2.0.0
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -52,7 +52,7 @@ public class BrowserSwitchClient {
 
         JSONObject metadata = browserSwitchOptions.getMetadata();
         BrowserSwitchRequest request =
-                new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme);
+                new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme, true);
         persistentStore.putActiveRequest(request, appContext);
 
         customTabsInternalClient.launchUrl(activity, browserSwitchUrl);
@@ -116,17 +116,20 @@ public class BrowserSwitchClient {
             return null;
         }
 
-        BrowserSwitchResult result;
+        BrowserSwitchResult result = null;
 
         Uri deepLinkUrl = intent.getData();
         if (deepLinkUrl != null && request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
-        } else {
+            persistentStore.clearActiveRequest(appContext);
+        } else if (request.getShouldNotifyCancellation()) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
+
+            request.setShouldNotifyCancellation(false);
+            persistentStore.putActiveRequest(request, activity);
         }
 
         // ensure that browser switch result is delivered exactly one time
-        persistentStore.clearActiveRequest(appContext);
         return result;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -123,13 +123,13 @@ public class BrowserSwitchClient {
             result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
             persistentStore.clearActiveRequest(appContext);
         } else if (request.getShouldNotifyCancellation()) {
+            // ensure that cancellation result is delivered exactly one time
             result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
 
             request.setShouldNotifyCancellation(false);
             persistentStore.putActiveRequest(request, activity);
         }
 
-        // ensure that browser switch result is delivered exactly one time
         return result;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
@@ -27,7 +27,7 @@ public class BrowserSwitchOptions {
      *                 {@link BrowserSwitchResult} when the app has re-entered the foreground
      * @return {@link BrowserSwitchOptions} reference to instance to allow setter invocations to be chained
      */
-    public BrowserSwitchOptions metadata(@NonNull JSONObject metadata) {
+    public BrowserSwitchOptions metadata(@Nullable JSONObject metadata) {
         this.metadata = metadata;
         return this;
     }
@@ -49,7 +49,7 @@ public class BrowserSwitchOptions {
      * @param url The target url to use for browser switch
      * @return {@link BrowserSwitchOptions} reference to instance to allow setter invocations to be chained
      */
-    public BrowserSwitchOptions url(@NonNull Uri url) {
+    public BrowserSwitchOptions url(@Nullable Uri url) {
         this.url = url;
         return this;
     }
@@ -61,7 +61,7 @@ public class BrowserSwitchOptions {
      *                        after browser switch
      * @return {@link BrowserSwitchOptions} reference to instance to allow setter invocations to be chained
      */
-    public BrowserSwitchOptions returnUrlScheme(@NonNull String returnUrlScheme) {
+    public BrowserSwitchOptions returnUrlScheme(@Nullable String returnUrlScheme) {
         this.returnUrlScheme = returnUrlScheme;
         return this;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -13,7 +13,7 @@ class BrowserSwitchRequest {
     private final int requestCode;
     private final JSONObject metadata;
     private final String returnUrlScheme;
-    private boolean shouldNotify;
+    private boolean shouldNotifyCancellation;
 
     static BrowserSwitchRequest fromJson(String json) throws JSONException {
         JSONObject jsonObject = new JSONObject(json);
@@ -25,12 +25,12 @@ class BrowserSwitchRequest {
         return new BrowserSwitchRequest(requestCode, Uri.parse(url), metadata, returnUrlScheme, shouldNotify);
     }
 
-    BrowserSwitchRequest(int requestCode, Uri url, JSONObject metadata, String returnUrlScheme, boolean shouldNotify) {
+    BrowserSwitchRequest(int requestCode, Uri url, JSONObject metadata, String returnUrlScheme, boolean shouldNotifyCancellation) {
         this.url = url;
         this.requestCode = requestCode;
         this.metadata = metadata;
         this.returnUrlScheme = returnUrlScheme;
-        this.shouldNotify = shouldNotify;
+        this.shouldNotifyCancellation = shouldNotifyCancellation;
     }
 
     Uri getUrl() {
@@ -45,12 +45,12 @@ class BrowserSwitchRequest {
         return metadata;
     }
 
-    boolean getShouldNotify() {
-        return shouldNotify;
+    boolean getShouldNotifyCancellation() {
+        return shouldNotifyCancellation;
     }
 
-    void setShouldNotify(boolean shouldNotify) {
-        this.shouldNotify = shouldNotify;
+    void setShouldNotifyCancellation(boolean shouldNotifyCancellation) {
+        this.shouldNotifyCancellation = shouldNotifyCancellation;
     }
 
     String toJson() throws JSONException {
@@ -58,7 +58,7 @@ class BrowserSwitchRequest {
         result.put("requestCode", requestCode);
         result.put("url", url.toString());
         result.put("returnUrlScheme", returnUrlScheme);
-        result.put("shouldNotify", shouldNotify);
+        result.put("shouldNotify", shouldNotifyCancellation);
         if (metadata != null) {
             result.put("metadata", metadata);
         }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -13,6 +13,7 @@ class BrowserSwitchRequest {
     private final int requestCode;
     private final JSONObject metadata;
     private final String returnUrlScheme;
+    private boolean shouldNotify;
 
     static BrowserSwitchRequest fromJson(String json) throws JSONException {
         JSONObject jsonObject = new JSONObject(json);
@@ -20,14 +21,16 @@ class BrowserSwitchRequest {
         String url = jsonObject.getString("url");
         String returnUrlScheme = jsonObject.getString("returnUrlScheme");
         JSONObject metadata = jsonObject.optJSONObject("metadata");
-        return new BrowserSwitchRequest(requestCode, Uri.parse(url), metadata, returnUrlScheme);
+        boolean shouldNotify = jsonObject.optBoolean("shouldNotify", true);
+        return new BrowserSwitchRequest(requestCode, Uri.parse(url), metadata, returnUrlScheme, shouldNotify);
     }
 
-    BrowserSwitchRequest(int requestCode, Uri url, JSONObject metadata, String returnUrlScheme) {
+    BrowserSwitchRequest(int requestCode, Uri url, JSONObject metadata, String returnUrlScheme, boolean shouldNotify) {
         this.url = url;
         this.requestCode = requestCode;
         this.metadata = metadata;
         this.returnUrlScheme = returnUrlScheme;
+        this.shouldNotify = shouldNotify;
     }
 
     Uri getUrl() {
@@ -42,11 +45,20 @@ class BrowserSwitchRequest {
         return metadata;
     }
 
+    boolean getShouldNotify() {
+        return shouldNotify;
+    }
+
+    void setShouldNotify(boolean shouldNotify) {
+        this.shouldNotify = shouldNotify;
+    }
+
     String toJson() throws JSONException {
         JSONObject result = new JSONObject();
         result.put("requestCode", requestCode);
         result.put("url", url.toString());
         result.put("returnUrlScheme", returnUrlScheme);
+        result.put("shouldNotify", shouldNotify);
         if (metadata != null) {
             result.put("metadata", metadata);
         }

--- a/browser-switch/src/main/java/com/braintreepayments/api/PersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/PersistentStore.java
@@ -9,7 +9,7 @@ class PersistentStore {
 
     @VisibleForTesting
     static final String PREFERENCES_KEY =
-        "com.braintreepayament.browserswitch.persistentstore";
+        "com.braintreepayment.browserswitch.persistentstore";
 
     static void put(String key, String value, Context context) {
         Context applicationContext = context.getApplicationContext();

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientTest.java
@@ -202,7 +202,7 @@ public class BrowserSwitchClientTest {
     }
 
     @Test
-    public void deliverResult_whenDeepLinkUrlExistsAndReturnUrlSchemeDoesNotMatchAndShouldNotifyCancellation_notifiesResultCANCELEDAndSetsRequestShouldNotifyCancellationToFalse() {
+    public void deliverResult_whenDeepLinkUrlExists_AndReturnUrlSchemeDoesNotMatch_AndShouldNotifyCancellation_notifiesResultCANCELED_AndSetsRequestShouldNotifyCancellationToFalse() {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
         Uri deepLinkUrl = Uri.parse("another-return-url-scheme://test");

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -18,17 +18,30 @@ import static org.junit.Assert.assertTrue;
 public class BrowserSwitchRequestUnitTest {
 
     @Test
-    public void fromJson_withoutMetadata() throws JSONException {
+    public void fromJson_withoutShouldNotifyProperty_defaultsShouldNotifyToTrue() throws JSONException {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
                 "  \"returnUrlScheme\": \"my-return-url-scheme\"\n" +
                 "}";
         BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
+        assertTrue(sut.getShouldNotify());
+    }
+
+    @Test
+    public void fromJson_withoutMetadata() throws JSONException {
+        String json = "{\n" +
+                "  \"requestCode\": 123,\n" +
+                "  \"url\": \"https://example.com\",\n" +
+                "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": true\n" +
+                "}";
+        BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
 
         assertEquals(sut.getRequestCode(), 123);
         assertEquals(sut.getUrl().toString(), "https://example.com");
         assertNull(sut.getMetadata());
+        assertTrue(sut.getShouldNotify());
 
         assertTrue(sut.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
         assertFalse(sut.matchesDeepLinkUrlScheme(Uri.parse("another-return-url-scheme://test")));
@@ -39,7 +52,8 @@ public class BrowserSwitchRequestUnitTest {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
-                "  \"returnUrlScheme\": \"my-return-url-scheme\"\n" +
+                "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": false\n" +
                 "}";
         BrowserSwitchRequest original = BrowserSwitchRequest.fromJson(json);
         BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
@@ -47,6 +61,7 @@ public class BrowserSwitchRequestUnitTest {
         assertEquals(restored.getRequestCode(), original.getRequestCode());
         assertEquals(restored.getUrl(), original.getUrl());
         assertNull(restored.getMetadata());
+        assertFalse(restored.getShouldNotify());
 
         assertTrue(restored.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
         assertFalse(restored.matchesDeepLinkUrlScheme(Uri.parse("another-return-url-scheme://test")));
@@ -58,6 +73,7 @@ public class BrowserSwitchRequestUnitTest {
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
                 "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": true,\n" +
                 "  \"metadata\": {\n" +
                 "    \"testKey\": \"testValue\"" +
                 "  }" +
@@ -66,6 +82,7 @@ public class BrowserSwitchRequestUnitTest {
 
         assertEquals(sut.getRequestCode(), 123);
         assertEquals(sut.getUrl().toString(), "https://example.com");
+        assertTrue(sut.getShouldNotify());
         JSONAssert.assertEquals(sut.getMetadata(), new JSONObject().put("testKey", "testValue"), true);
 
         assertTrue(sut.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
@@ -78,6 +95,7 @@ public class BrowserSwitchRequestUnitTest {
                 "  \"requestCode\": 123,\n" +
                 "  \"url\": \"https://example.com\",\n" +
                 "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": false,\n" +
                 "  \"metadata\": {\n" +
                 "    \"testKey\": \"testValue\"" +
                 "  }" +
@@ -87,6 +105,7 @@ public class BrowserSwitchRequestUnitTest {
 
         assertEquals(restored.getRequestCode(), original.getRequestCode());
         assertEquals(restored.getUrl(), original.getUrl());
+        assertFalse(restored.getShouldNotify());
         JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
 
         assertTrue(restored.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -25,7 +25,7 @@ public class BrowserSwitchRequestUnitTest {
                 "  \"returnUrlScheme\": \"my-return-url-scheme\"\n" +
                 "}";
         BrowserSwitchRequest sut = BrowserSwitchRequest.fromJson(json);
-        assertTrue(sut.getShouldNotify());
+        assertTrue(sut.getShouldNotifyCancellation());
     }
 
     @Test
@@ -41,7 +41,7 @@ public class BrowserSwitchRequestUnitTest {
         assertEquals(sut.getRequestCode(), 123);
         assertEquals(sut.getUrl().toString(), "https://example.com");
         assertNull(sut.getMetadata());
-        assertTrue(sut.getShouldNotify());
+        assertTrue(sut.getShouldNotifyCancellation());
 
         assertTrue(sut.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
         assertFalse(sut.matchesDeepLinkUrlScheme(Uri.parse("another-return-url-scheme://test")));
@@ -61,7 +61,7 @@ public class BrowserSwitchRequestUnitTest {
         assertEquals(restored.getRequestCode(), original.getRequestCode());
         assertEquals(restored.getUrl(), original.getUrl());
         assertNull(restored.getMetadata());
-        assertFalse(restored.getShouldNotify());
+        assertFalse(restored.getShouldNotifyCancellation());
 
         assertTrue(restored.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
         assertFalse(restored.matchesDeepLinkUrlScheme(Uri.parse("another-return-url-scheme://test")));
@@ -82,7 +82,7 @@ public class BrowserSwitchRequestUnitTest {
 
         assertEquals(sut.getRequestCode(), 123);
         assertEquals(sut.getUrl().toString(), "https://example.com");
-        assertTrue(sut.getShouldNotify());
+        assertTrue(sut.getShouldNotifyCancellation());
         JSONAssert.assertEquals(sut.getMetadata(), new JSONObject().put("testKey", "testValue"), true);
 
         assertTrue(sut.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
@@ -105,7 +105,7 @@ public class BrowserSwitchRequestUnitTest {
 
         assertEquals(restored.getRequestCode(), original.getRequestCode());
         assertEquals(restored.getUrl(), original.getUrl());
-        assertFalse(restored.getShouldNotify());
+        assertFalse(restored.getShouldNotifyCancellation());
         JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
 
         assertTrue(restored.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -53,38 +53,24 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
     public void onClick(View v) {
         @IdRes int viewId = v.getId();
         if (viewId == R.id.browser_switch) {
-            startBrowserSwitch();
+            startBrowserSwitch(null);
         } else if (viewId == R.id.browser_switch_with_metadata) {
             JSONObject metadata = buildMetadataObject();
-            startBrowserSwitchWithMetadata(metadata);
+            startBrowserSwitch(metadata);
         }
     }
 
-    private void startBrowserSwitch() {
-        Uri url = buildBrowserSwitchUrl();
-        BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
-                .requestCode(1)
-                .url(url)
-                .returnUrlScheme(getReturnUrlScheme());
-
-        try {
-            getDemoActivity().startBrowserSwitch(browserSwitchOptions);
-        } catch (BrowserSwitchException e) {
-            String statusText = "Browser Switch Error: " + e.getMessage();
-            mBrowserSwitchStatusTextView.setText(statusText);
-            e.printStackTrace();
-        }
-    }
-
-    private void startBrowserSwitchWithMetadata(JSONObject metadata) {
+    private void startBrowserSwitch(@Nullable JSONObject metadata) {
         Uri url = buildBrowserSwitchUrl();
         BrowserSwitchOptions browserSwitchOptions = new BrowserSwitchOptions()
                 .metadata(metadata)
                 .requestCode(1)
                 .url(url)
                 .returnUrlScheme(getReturnUrlScheme());
+
         try {
             getDemoActivity().startBrowserSwitch(browserSwitchOptions);
+            clearTextViews();
         } catch (BrowserSwitchException e) {
             String statusText = "Browser Switch Error: " + e.getMessage();
             mBrowserSwitchStatusTextView.setText(statusText);
@@ -106,6 +92,12 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
             // do nothing
         }
         return null;
+    }
+
+    private void clearTextViews() {
+        mBrowserSwitchStatusTextView.setText("");
+        mSelectedColorTextView.setText("");
+        mMetadataTextView.setText("");
     }
 
     public void onBrowserSwitchResult(BrowserSwitchResult result) {


### PR DESCRIPTION
### Summary of changes

 - Update `BrowserSwitchClient#deliverResult()` to allow canceled browser switches a chance to reach the success state (See braintree_android [#409](https://github.com/braintree/braintree_android/issues/409))
- Fix nullability annotations in `BrowserSwitchOptions` setters
- Fix shared preferences key typo

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sestevens 
- @sshropshire