### PR TITLE
Get Browser Switch Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Add `BrowserSwitchClient#getResult()` to preview a browser switch result before it is delivered.
+
 ## 2.0.1
 
 * Update `BrowserSwitchClient#deliverResult()` to allow canceled browser switches a chance to reach the success state (See braintree_android [#409](https://github.com/braintree/braintree_android/issues/409))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Add `BrowserSwitchClient#getResult()` to preview a browser switch result before it is delivered.
+* Add internal methods for usage with other Braintree libraries.
 
 ## 2.0.1
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -142,7 +142,7 @@ public class BrowserSwitchClient {
      *
      * @param activity the activity that received the deep link back into the app
      */
-    public BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
+    BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
         Intent intent = activity.getIntent();
         Context appContext = activity.getApplicationContext();
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -107,6 +107,42 @@ public class BrowserSwitchClient {
      * @param activity the activity that received the deep link back into the app
      */
     public BrowserSwitchResult deliverResult(@NonNull FragmentActivity activity) {
+        BrowserSwitchResult result = getResult(activity);
+        if (result != null) {
+
+            Context appContext = activity.getApplicationContext();
+            BrowserSwitchRequest request = persistentStore.getActiveRequest(appContext);
+
+            @BrowserSwitchStatus int status = result.getStatus();
+            switch (status) {
+                case BrowserSwitchStatus.SUCCESS:
+                    // ensure that success result is delivered exactly once
+                    persistentStore.clearActiveRequest(appContext);
+                    break;
+                case BrowserSwitchStatus.CANCELED:
+                    // ensure that cancellation result is delivered exactly once, but allow for
+                    // a cancellation result to remain in shared storage in case it
+                    // later becomes successful
+                    request.setShouldNotifyCancellation(false);
+                    persistentStore.putActiveRequest(request, activity);
+                    break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Peek at a pending browser switch result to an Android activity.
+     *
+     * We recommend you call this method in onResume to receive a browser switch result once your
+     * app has re-entered the foreground.
+     *
+     * This can be used in place of {@link BrowserSwitchClient#deliverResult(FragmentActivity)} when
+     * you want to know the contents of a pending browser switch result before it is delivered.
+     *
+     * @param activity the activity that received the deep link back into the app
+     */
+    public BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
         Intent intent = activity.getIntent();
         Context appContext = activity.getApplicationContext();
 
@@ -121,13 +157,8 @@ public class BrowserSwitchClient {
         Uri deepLinkUrl = intent.getData();
         if (deepLinkUrl != null && request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
-            persistentStore.clearActiveRequest(appContext);
         } else if (request.getShouldNotifyCancellation()) {
-            // ensure that cancellation result is delivered exactly one time
             result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
-
-            request.setShouldNotifyCancellation(false);
-            persistentStore.putActiveRequest(request, activity);
         }
 
         return result;

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-public class BrowserSwitchClientTest {
+public class BrowserSwitchClientUnitTest {
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();

--- a/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ChromeCustomTabsInternalClientTest {
+public class ChromeCustomTabsInternalClientUnitTest {
 
     CustomTabsIntent customTabsIntent;
     CustomTabsIntent.Builder customTabsIntentBuilder;


### PR DESCRIPTION
### Summary of changes

 - Add `getResult()` method to `BrowserSwitchClient` to allow "previews" of a pending browser switch result before it is delivered.
 - Rename `BrowserSwitchClientTest` to `BrowserSwitchClientUnitTest`
 - Rename `ChromeCustomTabsInternalClientTest` to `ChromeCustomTabsInternalClientUnitTest`

### Notes
- `getResult()` method already has full test coverage through `deliverResult()`

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sshropshire
