### PR TITLE
Browser Switch Launcher and Observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Create `BrowserSwitchLauncher`
 * Create `BrowserSwitchObserver`
-* Deprecate `BrowserSwitchClient`
+* Deprecate `BrowserSwitchClient` in favor of `BrowserSwitchLauncher`
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Create `BrowserSwitchLauncher`
 * Create `BrowserSwitchObserver`
-* Deprecate `BrowserSwitchClient` in favor of `BrowserSwitchLauncher`
+* Deprecate `BrowserSwitchClient` in favor of `BrowserSwitchLauncher` and `BrowserSwitchObserver`
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Create `BrowserSwitchLauncher`
+* Create `BrowserSwitchObserver`
+* Deprecate `BrowserSwitchClient`
+
 ## 2.1.1
 
 * Fallback to browser when Chrome Custom Tabs is unavailable (thanks! @calvarez-ov)

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -24,6 +24,7 @@ public class BrowserSwitchClient {
     /**
      * Construct a client that manages the logic for browser switching.
      */
+    @SuppressWarnings("unused")
     public BrowserSwitchClient() {
         this(new BrowserSwitchInspector(), BrowserSwitchPersistentStore.getInstance(), new ChromeCustomTabsInternalClient());
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 /**
  * Client that manages the logic for browser switching.
  */
+@Deprecated
 public class BrowserSwitchClient {
 
     private final BrowserSwitchInspector browserSwitchInspector;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
@@ -31,7 +31,7 @@ public class BrowserSwitchLauncher {
         this.customTabsInternalClient = customTabsInternalClient;
     }
 
-    void launch(@NonNull FragmentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException  {
+    public void launch(@NonNull FragmentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException  {
         assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
 
         Context appContext = activity.getApplicationContext();

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
@@ -1,0 +1,92 @@
+package com.braintreepayments.api;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.FragmentActivity;
+
+import org.json.JSONObject;
+
+public class BrowserSwitchLauncher {
+
+    private final BrowserSwitchInspector browserSwitchInspector;
+    private final BrowserSwitchPersistentStore persistentStore;
+
+    private final ChromeCustomTabsInternalClient customTabsInternalClient;
+
+    /**
+     * Construct a launcher to start a browser switch.
+     */
+    public BrowserSwitchLauncher() {
+        this(new BrowserSwitchInspector(), BrowserSwitchPersistentStore.getInstance(), new ChromeCustomTabsInternalClient());
+    }
+
+    @VisibleForTesting
+    BrowserSwitchLauncher(BrowserSwitchInspector browserSwitchInspector, BrowserSwitchPersistentStore persistentStore, ChromeCustomTabsInternalClient customTabsInternalClient) {
+        this.browserSwitchInspector = browserSwitchInspector;
+        this.persistentStore = persistentStore;
+        this.customTabsInternalClient = customTabsInternalClient;
+    }
+
+    void launch(@NonNull FragmentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException  {
+        assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
+
+        Context appContext = activity.getApplicationContext();
+
+        Uri browserSwitchUrl = browserSwitchOptions.getUrl();
+        int requestCode = browserSwitchOptions.getRequestCode();
+        String returnUrlScheme = browserSwitchOptions.getReturnUrlScheme();
+
+        JSONObject metadata = browserSwitchOptions.getMetadata();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme, true);
+        persistentStore.putActiveRequest(request, appContext);
+
+        if (browserSwitchInspector.deviceHasChromeCustomTabs(appContext)) {
+            customTabsInternalClient.launchUrl(activity, browserSwitchUrl);
+        } else {
+            Intent launchUrlInBrowser = new Intent(Intent.ACTION_VIEW, browserSwitchUrl);
+            activity.startActivity(launchUrlInBrowser);
+        }
+    }
+
+    void assertCanPerformBrowserSwitch(FragmentActivity activity, BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {
+        Context appContext = activity.getApplicationContext();
+
+        Uri browserSwitchUrl = browserSwitchOptions.getUrl();
+        int requestCode = browserSwitchOptions.getRequestCode();
+        String returnUrlScheme = browserSwitchOptions.getReturnUrlScheme();
+
+        String errorMessage = null;
+
+        if (!isValidRequestCode(requestCode)) {
+            errorMessage = "Request code cannot be Integer.MIN_VALUE";
+        } else if (returnUrlScheme == null) {
+            errorMessage = "A returnUrlScheme is required.";
+        } else if (!browserSwitchInspector.isDeviceConfiguredForDeepLinking(appContext, returnUrlScheme)) {
+            errorMessage =
+                    "The return url scheme was not set up, incorrectly set up, " +
+                            "or more than one Activity on this device defines the same url " +
+                            "scheme in it's Android Manifest. See " +
+                            "https://github.com/braintree/browser-switch-android for more " +
+                            "information on setting up a return url scheme.";
+        } else if (!browserSwitchInspector.deviceHasBrowser(appContext)) {
+            StringBuilder messageBuilder = new StringBuilder("No installed activities can open this URL");
+            if (browserSwitchUrl != null) {
+                messageBuilder.append(String.format(": %s", browserSwitchUrl.toString()));
+            }
+            errorMessage = messageBuilder.toString();
+        }
+
+        if (errorMessage != null) {
+            throw new BrowserSwitchException(errorMessage);
+        }
+    }
+
+    private boolean isValidRequestCode(int requestCode) {
+        return requestCode != Integer.MIN_VALUE;
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
@@ -34,6 +34,13 @@ public class BrowserSwitchLauncher {
         this.customTabsInternalClient = customTabsInternalClient;
     }
 
+   /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android activity.
+     *
+     * @param activity the activity used to start browser switch
+     * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
+     */
     public void launch(@NonNull FragmentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException  {
         assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchLauncher.java
@@ -11,7 +11,7 @@ import androidx.fragment.app.FragmentActivity;
 import org.json.JSONObject;
 
 /**
- * Class that manages the logic for browser switching.
+ * Class that manages the logic to initiate a browser switch.
  */
 public class BrowserSwitchLauncher {
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
@@ -1,5 +1,5 @@
 package com.braintreepayments.api;
 
-public interface BrowserSwitchResultListener {
+public interface BrowserSwitchListener {
     void onBrowserSwitchResult(BrowserSwitchResult result);
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListener.java
@@ -1,5 +1,9 @@
 package com.braintreepayments.api;
 
+/**
+ * Implement this interface to receive notifications from a {@link BrowserSwitchObserver} that a
+ * browser switch has occurred.
+ */
 public interface BrowserSwitchListener {
     void onBrowserSwitchResult(BrowserSwitchResult result);
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -1,0 +1,27 @@
+package com.braintreepayments.api;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrowserSwitchListenerFinder {
+
+    List<BrowserSwitchListener> findActiveListeners(FragmentActivity activity) {
+        List<BrowserSwitchListener> result = new ArrayList<>();
+        if (activity instanceof BrowserSwitchListener) {
+            result.add((BrowserSwitchListener) activity);
+        }
+
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        List<Fragment> fragments = fragmentManager.getFragments();
+        for (Fragment fragment : fragments) {
+            if (fragment instanceof BrowserSwitchListener) {
+                result.add((BrowserSwitchListener) fragment);
+            }
+        }
+        return result;
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -7,6 +7,11 @@ import androidx.fragment.app.FragmentManager;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Locate all {@link BrowserSwitchListener} references associated with an activity. A listener can
+ * be the root activity, along with any fragments attached to that activity, and any child,
+ * grand-child, great-grand-child etc. fragments that can be traced back to the root activity.
+ */
 class BrowserSwitchListenerFinder {
 
     List<BrowserSwitchListener> findActiveListeners(FragmentActivity activity) {

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -10,18 +10,18 @@ import java.util.List;
 class BrowserSwitchListenerFinder {
 
     List<BrowserSwitchListener> findActiveListeners(FragmentActivity activity) {
-        List<BrowserSwitchListener> result = new ArrayList<>();
+        List<BrowserSwitchListener> listeners = new ArrayList<>();
         if (activity instanceof BrowserSwitchListener) {
-            result.add((BrowserSwitchListener) activity);
+            listeners.add((BrowserSwitchListener) activity);
         }
 
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         List<Fragment> fragments = fragmentManager.getFragments();
         for (Fragment fragment : fragments) {
             if (fragment instanceof BrowserSwitchListener) {
-                result.add((BrowserSwitchListener) fragment);
+                listeners.add((BrowserSwitchListener) fragment);
             }
         }
-        return result;
+        return listeners;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -22,13 +22,24 @@ class BrowserSwitchListenerFinder {
                 listeners.add((BrowserSwitchListener) fragment);
             }
 
-            FragmentManager childFragmentManager = fragment.getChildFragmentManager();
-            List<Fragment> childFragments = childFragmentManager.getFragments();
-            for (Fragment childFragment : childFragments) {
-                if (childFragment instanceof BrowserSwitchListener) {
-                    listeners.add((BrowserSwitchListener) childFragment);
-                }
+            listeners.addAll(findChildFragmentActiveListeners(fragment));
+        }
+        return listeners;
+    }
+
+    private List<BrowserSwitchListener> findChildFragmentActiveListeners(Fragment fragment) {
+        List<BrowserSwitchListener> listeners = new ArrayList<>();
+
+        FragmentManager childFragmentManager = fragment.getChildFragmentManager();
+        List<Fragment> childFragments = childFragmentManager.getFragments();
+        for (Fragment childFragment : childFragments) {
+            if (childFragment instanceof BrowserSwitchListener) {
+                listeners.add((BrowserSwitchListener) childFragment);
             }
+
+            // recursively find additional child fragments until no descendant listener
+            // fragments exist
+            listeners.addAll(findChildFragmentActiveListeners(childFragment));
         }
         return listeners;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -7,7 +7,7 @@ import androidx.fragment.app.FragmentManager;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BrowserSwitchListenerFinder {
+class BrowserSwitchListenerFinder {
 
     List<BrowserSwitchListener> findActiveListeners(FragmentActivity activity) {
         List<BrowserSwitchListener> result = new ArrayList<>();

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchListenerFinder.java
@@ -21,6 +21,14 @@ class BrowserSwitchListenerFinder {
             if (fragment instanceof BrowserSwitchListener) {
                 listeners.add((BrowserSwitchListener) fragment);
             }
+
+            FragmentManager childFragmentManager = fragment.getChildFragmentManager();
+            List<Fragment> childFragments = childFragmentManager.getFragments();
+            for (Fragment childFragment : childFragments) {
+                if (childFragment instanceof BrowserSwitchListener) {
+                    listeners.add((BrowserSwitchListener) childFragment);
+                }
+            }
         }
         return listeners;
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
@@ -39,6 +39,8 @@ public class BrowserSwitchObserver {
                 listener.onBrowserSwitchResult(result);
             }
 
+            // TODO: consider if we should skip modifying persistent store when
+            // there are no active listeners to deliver a result to
             @BrowserSwitchStatus int status = result.getStatus();
             switch (status) {
                 case BrowserSwitchStatus.SUCCESS:

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
@@ -33,17 +33,17 @@ public class BrowserSwitchObserver {
             BrowserSwitchRequest request = persistentStore.getActiveRequest(appContext);
 
             boolean wasDelivered = false;
-            if (activity instanceof BrowserSwitchResultListener) {
+            if (activity instanceof BrowserSwitchListener) {
                 wasDelivered = true;
-                ((BrowserSwitchResultListener) activity).onBrowserSwitchResult(result);
+                ((BrowserSwitchListener) activity).onBrowserSwitchResult(result);
             }
 
             FragmentManager fragmentManager = activity.getSupportFragmentManager();
             List<Fragment> fragments = fragmentManager.getFragments();
             for (Fragment fragment : fragments) {
-                if (fragment instanceof BrowserSwitchResultListener) {
+                if (fragment instanceof BrowserSwitchListener) {
                     wasDelivered = true;
-                    ((BrowserSwitchResultListener) fragment).onBrowserSwitchResult(result);
+                    ((BrowserSwitchListener) fragment).onBrowserSwitchResult(result);
                 }
             }
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
@@ -1,0 +1,101 @@
+package com.braintreepayments.api;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import java.util.List;
+
+public class BrowserSwitchObserver {
+
+    private final BrowserSwitchPersistentStore persistentStore;
+
+    public BrowserSwitchObserver() {
+        this(BrowserSwitchPersistentStore.getInstance());
+    }
+
+    @VisibleForTesting
+    BrowserSwitchObserver(BrowserSwitchPersistentStore persistentStore) {
+        this.persistentStore = persistentStore;
+    }
+
+    public void onActivityResumed(FragmentActivity activity) {
+        BrowserSwitchResult result = getResult(activity);
+        if (result != null) {
+
+            Context appContext = activity.getApplicationContext();
+            BrowserSwitchRequest request = persistentStore.getActiveRequest(appContext);
+
+            boolean wasDelivered = false;
+            if (activity instanceof BrowserSwitchResultListener) {
+                wasDelivered = true;
+                ((BrowserSwitchResultListener) activity).onBrowserSwitchResult(result);
+            }
+
+            FragmentManager fragmentManager = activity.getSupportFragmentManager();
+            List<Fragment> fragments = fragmentManager.getFragments();
+            for (Fragment fragment : fragments) {
+                if (fragment instanceof BrowserSwitchResultListener) {
+                    wasDelivered = true;
+                    ((BrowserSwitchResultListener) fragment).onBrowserSwitchResult(result);
+                }
+            }
+
+            if (wasDelivered) {
+                @BrowserSwitchStatus int status = result.getStatus();
+                switch (status) {
+                    case BrowserSwitchStatus.SUCCESS:
+                        // ensure that success result is delivered exactly once
+                        persistentStore.clearActiveRequest(appContext);
+                        break;
+                    case BrowserSwitchStatus.CANCELED:
+                        // ensure that cancellation result is delivered exactly once, but allow for
+                        // a cancellation result to remain in shared storage in case it
+                        // later becomes successful
+                        request.setShouldNotifyCancellation(false);
+                        persistentStore.putActiveRequest(request, activity);
+                        break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Peek at a pending browser switch result to an Android activity.
+     *
+     * We recommend you call this method in onResume to receive a browser switch result once your
+     * app has re-entered the foreground.
+     *
+     * This can be used in place of {@link BrowserSwitchClient#deliverResult(FragmentActivity)} when
+     * you want to know the contents of a pending browser switch result before it is delivered.
+     *
+     * @param activity the activity that received the deep link back into the app
+     */
+    BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
+        Intent intent = activity.getIntent();
+        Context appContext = activity.getApplicationContext();
+
+        BrowserSwitchRequest request = persistentStore.getActiveRequest(appContext);
+        if (request == null || intent == null) {
+            // no pending browser switch request found
+            return null;
+        }
+
+        BrowserSwitchResult result = null;
+
+        Uri deepLinkUrl = intent.getData();
+        if (deepLinkUrl != null && request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
+            result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
+        } else if (request.getShouldNotifyCancellation()) {
+            result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
+        }
+
+        return result;
+    }
+}

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchObserver.java
@@ -12,6 +12,10 @@ import androidx.fragment.app.FragmentManager;
 
 import java.util.List;
 
+/**
+ * Class that is used to deliver a browser switch result to a deep link destination FragmentActivity
+ * and any attached Fragments that implement {@link BrowserSwitchListener}.
+ */
 public class BrowserSwitchObserver {
 
     private final BrowserSwitchPersistentStore persistentStore;
@@ -27,6 +31,10 @@ public class BrowserSwitchObserver {
         this.listenerFinder = listenerFinder;
     }
 
+    /**
+     * Call this method in FragmentActivity#onResume to notify all listeners of a browser switch result.
+     * @param activity Deep link destination activity
+     */
     public void onActivityResumed(FragmentActivity activity) {
         BrowserSwitchResult result = getResult(activity);
         if (result != null) {

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResultListener.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResultListener.java
@@ -1,0 +1,5 @@
+package com.braintreepayments.api;
+
+public interface BrowserSwitchResultListener {
+    void onBrowserSwitchResult(BrowserSwitchResult result);
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchLauncherUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchLauncherUnitTest.java
@@ -1,0 +1,212 @@
+package com.braintreepayments.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.fragment.app.FragmentActivity;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class BrowserSwitchLauncherUnitTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private BrowserSwitchPersistentStore persistentStore;
+    private BrowserSwitchInspector browserSwitchInspector;
+
+    private ChromeCustomTabsInternalClient customTabsInternalClient;
+
+    private Uri browserSwitchDestinationUrl;
+    private Context applicationContext;
+
+    private FragmentActivity activity;
+
+    @Before
+    public void beforeEach() {
+        persistentStore = mock(BrowserSwitchPersistentStore.class);
+
+        browserSwitchInspector = mock(BrowserSwitchInspector.class);
+        customTabsInternalClient = mock(ChromeCustomTabsInternalClient.class);
+
+        browserSwitchDestinationUrl = Uri.parse("https://example.com/browser_switch_destination");
+
+        activity = mock(FragmentActivity.class);
+        applicationContext = mock(Context.class);
+
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    }
+
+    @Test
+    public void launch_whenChromeCustomTabsSupported_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() throws BrowserSwitchException {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+        when(browserSwitchInspector.deviceHasChromeCustomTabs(applicationContext)).thenReturn(true);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+        sut.launch(activity, options);
+
+        verify(customTabsInternalClient).launchUrl(activity, browserSwitchDestinationUrl);
+        verify(activity, never()).startActivity(any(Intent.class));
+
+        ArgumentCaptor<BrowserSwitchRequest> captor =
+                ArgumentCaptor.forClass(BrowserSwitchRequest.class);
+        verify(persistentStore).putActiveRequest(captor.capture(), same(applicationContext));
+
+        BrowserSwitchRequest browserSwitchRequest = captor.getValue();
+        assertEquals(browserSwitchRequest.getRequestCode(), 123);
+        assertEquals(browserSwitchRequest.getUrl(), browserSwitchDestinationUrl);
+        assertSame(browserSwitchRequest.getMetadata(), metadata);
+        assertTrue(browserSwitchRequest.getShouldNotifyCancellation());
+    }
+
+    @Test
+    public void launch_whenChromeCustomTabsNotSupported_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() throws BrowserSwitchException {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+        when(browserSwitchInspector.deviceHasChromeCustomTabs(applicationContext)).thenReturn(false);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+        sut.launch(activity, options);
+
+        verify(customTabsInternalClient, never()).launchUrl(activity, browserSwitchDestinationUrl);
+
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity).startActivity(intentCaptor.capture());
+
+        Intent intent = intentCaptor.getValue();
+        assertEquals(intent.getData(), browserSwitchDestinationUrl);
+
+        ArgumentCaptor<BrowserSwitchRequest> captor =
+                ArgumentCaptor.forClass(BrowserSwitchRequest.class);
+        verify(persistentStore).putActiveRequest(captor.capture(), same(applicationContext));
+
+        BrowserSwitchRequest browserSwitchRequest = captor.getValue();
+        assertEquals(browserSwitchRequest.getRequestCode(), 123);
+        assertEquals(browserSwitchRequest.getUrl(), browserSwitchDestinationUrl);
+        assertSame(browserSwitchRequest.getMetadata(), metadata);
+        assertTrue(browserSwitchRequest.getShouldNotifyCancellation());
+    }
+
+    @Test
+    public void launch_whenRequestCodeIsIntegerMinValue_throwsError() {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(Integer.MIN_VALUE)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+        try {
+            sut.launch(activity, options);
+            fail("should fail");
+        } catch (BrowserSwitchException e) {
+            assertEquals(e.getMessage(), "Request code cannot be Integer.MIN_VALUE");
+        }
+    }
+
+    @Test
+    public void launch_whenDeviceIsNotConfiguredForDeepLinking_throwsError() {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(false);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+
+        try {
+            sut.launch(activity, options);
+            fail("should fail");
+        } catch (BrowserSwitchException e) {
+            assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
+                    "Activity on this device defines the same url scheme in it's Android Manifest. " +
+                    "See https://github.com/braintree/browser-switch-android for more information on " +
+                    "setting up a return url scheme.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void launch_whenNoActivityFoundCanOpenURL_throwsError() {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(false);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+        try {
+            sut.launch(activity, options);
+            fail("should fail");
+        } catch (BrowserSwitchException e) {
+            assertEquals("No installed activities can open this URL: https://example.com/browser_switch_destination", e.getMessage());
+        }
+    }
+
+    @Test
+    public void launch_whenNoReturnUrlSchemeSet_throwsError() {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+
+        BrowserSwitchLauncher sut = new BrowserSwitchLauncher(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .returnUrlScheme(null)
+                .url(browserSwitchDestinationUrl)
+                .metadata(metadata);
+        try {
+            sut.launch(activity, options);
+            fail("should fail");
+        } catch (BrowserSwitchException e) {
+            assertEquals("A returnUrlScheme is required.", e.getMessage());
+        }
+    }
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
@@ -13,7 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class BrowserSwitchListenerFinderUnitTest {
@@ -30,8 +29,8 @@ public class BrowserSwitchListenerFinderUnitTest {
         }
     }
 
-    private FragmentActivity plainActivity;
     private ListenerActivity listenerActivity;
+    private FragmentActivity nonListenerActivity;
 
     private FragmentManager fragmentManager;
 
@@ -42,20 +41,20 @@ public class BrowserSwitchListenerFinderUnitTest {
     public void beforeEach() {
         fragmentManager = mock(FragmentManager.class);
 
-        plainActivity = mock(FragmentActivity.class);
+        nonListenerActivity = mock(FragmentActivity.class);
         listenerActivity = mock(ListenerActivity.class);
 
         fragment = mock(Fragment.class);
         listenerFragment = mock(ListenerFragment.class);
 
-        when(plainActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+        when(nonListenerActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
         when(listenerActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
     }
 
     @Test
     public void findActiveListeners_whenActivityIsNotAListener_excludesActivityInTheResult() {
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
-        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(plainActivity);
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(nonListenerActivity);
 
         assertEquals(0, activeListeners.size());
     }
@@ -74,7 +73,7 @@ public class BrowserSwitchListenerFinderUnitTest {
         when(fragmentManager.getFragments()).thenReturn(Arrays.asList(fragment, listenerFragment));
 
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
-        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(plainActivity);
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(nonListenerActivity);
 
         assertEquals(1, activeListeners.size());
         assertSame(activeListeners.get(0), listenerFragment);

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
@@ -100,7 +100,9 @@ public class BrowserSwitchListenerFinderUnitTest {
     @Test
     public void findActiveListeners_whenNonListenerActivityHasGrandchildListenerFragments_includesFragmentsInResult() {
         when(fragmentManager.getFragments()).thenReturn(Collections.singletonList(fragment));
-        when(childFragmentManager.getFragments()).thenReturn(Collections.singletonList(listenerFragment));
+        when(childFragmentManager.getFragments())
+                .thenReturn(Collections.singletonList(listenerFragment))
+                .thenReturn(Collections.emptyList());
 
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
         List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(activity);
@@ -112,7 +114,9 @@ public class BrowserSwitchListenerFinderUnitTest {
     @Test
     public void findActiveListeners_whenListenerActivityHasGrandchildListenerFragments_includesFragmentsInResult() {
         when(fragmentManager.getFragments()).thenReturn(Collections.singletonList(fragment));
-        when(childFragmentManager.getFragments()).thenReturn(Collections.singletonList(listenerFragment));
+        when(childFragmentManager.getFragments())
+                .thenReturn(Collections.singletonList(listenerFragment))
+                .thenReturn(Collections.emptyList());
 
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
         List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(listenerActivity);

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class BrowserSwitchListenerFinderUnitTest {
@@ -30,9 +31,10 @@ public class BrowserSwitchListenerFinderUnitTest {
     }
 
     private ListenerActivity listenerActivity;
-    private FragmentActivity nonListenerActivity;
+    private FragmentActivity activity;
 
     private FragmentManager fragmentManager;
+    private FragmentManager childFragmentManager;
 
     private Fragment fragment;
     private ListenerFragment listenerFragment;
@@ -40,21 +42,25 @@ public class BrowserSwitchListenerFinderUnitTest {
     @Before
     public void beforeEach() {
         fragmentManager = mock(FragmentManager.class);
+        childFragmentManager = mock(FragmentManager.class);
 
-        nonListenerActivity = mock(FragmentActivity.class);
+        activity = mock(FragmentActivity.class);
         listenerActivity = mock(ListenerActivity.class);
 
         fragment = mock(Fragment.class);
         listenerFragment = mock(ListenerFragment.class);
 
-        when(nonListenerActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+        when(activity.getSupportFragmentManager()).thenReturn(fragmentManager);
         when(listenerActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+
+        when(fragment.getChildFragmentManager()).thenReturn(childFragmentManager);
+        when(listenerFragment.getChildFragmentManager()).thenReturn(childFragmentManager);
     }
 
     @Test
     public void findActiveListeners_whenActivityIsNotAListener_excludesActivityInTheResult() {
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
-        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(nonListenerActivity);
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(activity);
 
         assertEquals(0, activeListeners.size());
     }
@@ -69,11 +75,11 @@ public class BrowserSwitchListenerFinderUnitTest {
     }
 
     @Test
-    public void findActiveListeners_whenPlainActivityFragmentMangerHasListenerFragments_includesFragmentsInResult() {
+    public void findActiveListeners_whenNonListenerActivityFragmentMangerHasListenerFragments_includesFragmentsInResult() {
         when(fragmentManager.getFragments()).thenReturn(Arrays.asList(fragment, listenerFragment));
 
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
-        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(nonListenerActivity);
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(activity);
 
         assertEquals(1, activeListeners.size());
         assertSame(activeListeners.get(0), listenerFragment);
@@ -82,6 +88,31 @@ public class BrowserSwitchListenerFinderUnitTest {
     @Test
     public void findActiveListeners_whenListenerActivityFragmentMangerHasListenerFragments_includesFragmentsInResult() {
         when(fragmentManager.getFragments()).thenReturn(Arrays.asList(listenerFragment, fragment));
+
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(listenerActivity);
+
+        assertEquals(2, activeListeners.size());
+        assertSame(activeListeners.get(0), listenerActivity);
+        assertSame(activeListeners.get(1), listenerFragment);
+    }
+
+    @Test
+    public void findActiveListeners_whenNonListenerActivityHasGrandchildListenerFragments_includesFragmentsInResult() {
+        when(fragmentManager.getFragments()).thenReturn(Collections.singletonList(fragment));
+        when(childFragmentManager.getFragments()).thenReturn(Collections.singletonList(listenerFragment));
+
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(activity);
+
+        assertEquals(1, activeListeners.size());
+        assertSame(activeListeners.get(0), listenerFragment);
+    }
+
+    @Test
+    public void findActiveListeners_whenListenerActivityHasGrandchildListenerFragments_includesFragmentsInResult() {
+        when(fragmentManager.getFragments()).thenReturn(Collections.singletonList(fragment));
+        when(childFragmentManager.getFragments()).thenReturn(Collections.singletonList(listenerFragment));
 
         BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
         List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(listenerActivity);

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchListenerFinderUnitTest.java
@@ -1,0 +1,94 @@
+package com.braintreepayments.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BrowserSwitchListenerFinderUnitTest {
+
+    private static class ListenerActivity extends FragmentActivity implements BrowserSwitchListener {
+        @Override
+        public void onBrowserSwitchResult(BrowserSwitchResult result) {
+        }
+    }
+
+    private static class ListenerFragment extends Fragment implements BrowserSwitchListener {
+        @Override
+        public void onBrowserSwitchResult(BrowserSwitchResult result) {
+        }
+    }
+
+    private FragmentActivity plainActivity;
+    private ListenerActivity listenerActivity;
+
+    private FragmentManager fragmentManager;
+
+    private Fragment fragment;
+    private ListenerFragment listenerFragment;
+
+    @Before
+    public void beforeEach() {
+        fragmentManager = mock(FragmentManager.class);
+
+        plainActivity = mock(FragmentActivity.class);
+        listenerActivity = mock(ListenerActivity.class);
+
+        fragment = mock(Fragment.class);
+        listenerFragment = mock(ListenerFragment.class);
+
+        when(plainActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+        when(listenerActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+    }
+
+    @Test
+    public void findActiveListeners_whenActivityIsNotAListener_excludesActivityInTheResult() {
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(plainActivity);
+
+        assertEquals(0, activeListeners.size());
+    }
+
+    @Test
+    public void findActiveListeners_whenActivityIsAListener_includesActivityInTheResult() {
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(listenerActivity);
+
+        assertEquals(1, activeListeners.size());
+        assertSame(activeListeners.get(0), listenerActivity);
+    }
+
+    @Test
+    public void findActiveListeners_whenPlainActivityFragmentMangerHasListenerFragments_includesFragmentsInResult() {
+        when(fragmentManager.getFragments()).thenReturn(Arrays.asList(fragment, listenerFragment));
+
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(plainActivity);
+
+        assertEquals(1, activeListeners.size());
+        assertSame(activeListeners.get(0), listenerFragment);
+    }
+
+    @Test
+    public void findActiveListeners_whenListenerActivityFragmentMangerHasListenerFragments_includesFragmentsInResult() {
+        when(fragmentManager.getFragments()).thenReturn(Arrays.asList(listenerFragment, fragment));
+
+        BrowserSwitchListenerFinder sut = new BrowserSwitchListenerFinder();
+        List<BrowserSwitchListener> activeListeners = sut.findActiveListeners(listenerActivity);
+
+        assertEquals(2, activeListeners.size());
+        assertSame(activeListeners.get(0), listenerActivity);
+        assertSame(activeListeners.get(1), listenerFragment);
+    }
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
@@ -1,0 +1,7 @@
+package com.braintreepayments.api;
+
+import static org.junit.Assert.*;
+
+public class BrowserSwitchObserverUnitTest {
+
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
@@ -1,7 +1,180 @@
 package com.braintreepayments.api;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import androidx.fragment.app.FragmentActivity;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
 public class BrowserSwitchObserverUnitTest {
 
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private BrowserSwitchPersistentStore persistentStore;
+
+    private Uri browserSwitchDestinationUrl;
+    private Context applicationContext;
+
+    private FragmentActivity activity;
+
+    @Before
+    public void beforeEach() {
+        persistentStore = mock(BrowserSwitchPersistentStore.class);
+        browserSwitchDestinationUrl = Uri.parse("https://example.com/browser_switch_destination");
+
+        activity = mock(FragmentActivity.class);
+        applicationContext = mock(Context.class);
+
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+    }
+
+    @Test
+    public void onActivityResumed_whenDeepLinkUrlExistsAndReturnUrlSchemeMatches_clearsResultStoreAndNotifiesResultSUCCESS() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+
+        Uri deepLinkUrl = Uri.parse("return-url-scheme://test");
+        Intent deepLinkIntent = new Intent().setData(deepLinkUrl);
+        when(activity.getIntent()).thenReturn(deepLinkIntent);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request = new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", false);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNotNull(result);
+        assertEquals(123, result.getRequestCode());
+        assertSame(browserSwitchDestinationUrl, result.getRequestUrl());
+        assertEquals(BrowserSwitchStatus.SUCCESS, result.getStatus());
+        assertSame(requestMetadata, result.getRequestMetadata());
+        assertSame(deepLinkUrl, result.getDeepLinkUrl());
+
+        verify(persistentStore).clearActiveRequest(applicationContext);
+    }
+
+    @Test
+    public void onActivityResumed_whenDeepLinkUrlExists_AndReturnUrlSchemeDoesNotMatch_AndShouldNotifyCancellation_notifiesResultCANCELED_AndSetsRequestShouldNotifyCancellationToFalse() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+
+        Uri deepLinkUrl = Uri.parse("another-return-url-scheme://test");
+        Intent deepLinkIntent = new Intent().setData(deepLinkUrl);
+        when(activity.getIntent()).thenReturn(deepLinkIntent);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request = new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", true);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNotNull(result);
+        assertEquals(123, result.getRequestCode());
+        assertSame(browserSwitchDestinationUrl, result.getRequestUrl());
+        assertEquals(result.getStatus(), BrowserSwitchStatus.CANCELED);
+        assertSame(result.getRequestMetadata(), requestMetadata);
+        assertNull(result.getDeepLinkUrl());
+
+        ArgumentCaptor<BrowserSwitchRequest> captor = ArgumentCaptor.forClass(BrowserSwitchRequest.class);
+        verify(persistentStore).putActiveRequest(captor.capture(), same(activity));
+
+        BrowserSwitchRequest updatedRequest = captor.getValue();
+        assertSame(request, updatedRequest);
+        assertFalse(updatedRequest.getShouldNotifyCancellation());
+    }
+
+    @Test
+    public void onActivityResumed_whenDeepLinkUrlExistsAndReturnUrlSchemeDoesNotMatchAndShouldNotNotifyCancellation_returnsNull() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+
+        Uri deepLinkUrl = Uri.parse("another-return-url-scheme://test");
+        Intent deepLinkIntent = new Intent().setData(deepLinkUrl);
+        when(activity.getIntent()).thenReturn(deepLinkIntent);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request = new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", false);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNull(result);
+        verify(persistentStore, never()).putActiveRequest(any(BrowserSwitchRequest.class), any(FragmentActivity.class));
+    }
+
+    @Test
+    public void onActivityResumed_whenDeepLinkUrlDoesNotExistAndShouldNotifyCancellation_notifiesResultCANCELEDAndSetsRequestShouldNotifyCancellationToFalse() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(activity.getIntent()).thenReturn(new Intent());
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", true);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNotNull(result);
+        assertEquals(123, result.getRequestCode());
+        assertSame(browserSwitchDestinationUrl, result.getRequestUrl());
+        assertEquals(result.getStatus(), BrowserSwitchStatus.CANCELED);
+        assertSame(result.getRequestMetadata(), requestMetadata);
+        assertNull(result.getDeepLinkUrl());
+
+        ArgumentCaptor<BrowserSwitchRequest> captor = ArgumentCaptor.forClass(BrowserSwitchRequest.class);
+        verify(persistentStore).putActiveRequest(captor.capture(), same(activity));
+
+        BrowserSwitchRequest updatedRequest = captor.getValue();
+        assertSame(request, updatedRequest);
+        assertFalse(updatedRequest.getShouldNotifyCancellation());
+    }
+
+    @Test
+    public void onActivityResumed_whenDeepLinkUrlDoesNotExistAndShouldNotNotifyCancellation_returnsNull() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(activity.getIntent()).thenReturn(new Intent());
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", false);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNull(result);
+        verify(persistentStore, never()).putActiveRequest(any(BrowserSwitchRequest.class), any(FragmentActivity.class));
+    }
+
+    @Test
+    public void onActivityResumed_whenRequestIsNull_doesNothing() {
+        when(activity.getApplicationContext()).thenReturn(applicationContext);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(null);
+
+        BrowserSwitchObserver sut = new BrowserSwitchObserver(persistentStore);
+        BrowserSwitchResult result = sut.onActivityResumed(activity);
+
+        assertNull(result);
+        verify(persistentStore, never()).clearActiveRequest(activity);
+    }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
@@ -130,7 +130,7 @@ public class BrowserSwitchObserverUnitTest {
     }
 
     @Test
-    public void onActivityResumed_whenDeepLinkUrlExistsAndReturnUrlSchemeDoesNotMatchAndShouldNotNotifyCancellation_returnsNull() {
+    public void onActivityResumed_whenDeepLinkUrlExistsAndReturnUrlSchemeDoesNotMatchAndShouldNotNotifyCancellation_doesNothing() {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
         Uri deepLinkUrl = Uri.parse("another-return-url-scheme://test");

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchObserverUnitTest.java
@@ -189,7 +189,7 @@ public class BrowserSwitchObserverUnitTest {
     }
 
     @Test
-    public void onActivityResumed_whenDeepLinkUrlDoesNotExistAndShouldNotNotifyCancellation_returnsNull() {
+    public void onActivityResumed_whenDeepLinkUrlDoesNotExistAndShouldNotNotifyCancellation_doesNothing() {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
         when(activity.getIntent()).thenReturn(new Intent());
 

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.FragmentManager;
 
 import com.braintreepayments.api.BrowserSwitchClient;
 import com.braintreepayments.api.BrowserSwitchException;
+import com.braintreepayments.api.BrowserSwitchObserver;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.BrowserSwitchResult;
 
@@ -21,10 +22,14 @@ public class DemoActivity extends AppCompatActivity {
     @VisibleForTesting
     BrowserSwitchClient browserSwitchClient = null;
 
+    @VisibleForTesting
+    BrowserSwitchObserver browserSwitchObserver = null;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         browserSwitchClient = new BrowserSwitchClient();
+        browserSwitchObserver = new BrowserSwitchObserver();
 
         FragmentManager fm = getSupportFragmentManager();
         if (getDemoFragment() == null) {
@@ -37,14 +42,15 @@ public class DemoActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        browserSwitchObserver.onActivityResumed(this);
 
-        BrowserSwitchResult result = browserSwitchClient.deliverResult(this);
-        if (result != null) {
-            DemoFragment demoFragment = getDemoFragment();
-            if (demoFragment != null) {
-                demoFragment.onBrowserSwitchResult(result);
-            }
-        }
+//        BrowserSwitchResult result = browserSwitchClient.deliverResult(this);
+//        if (result != null) {
+//            DemoFragment demoFragment = getDemoFragment();
+//            if (demoFragment != null) {
+//                demoFragment.onBrowserSwitchResult(result);
+//            }
+//        }
     }
 
     public void startBrowserSwitch(BrowserSwitchOptions options) throws BrowserSwitchException {

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
@@ -43,14 +43,6 @@ public class DemoActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         browserSwitchObserver.onActivityResumed(this);
-
-//        BrowserSwitchResult result = browserSwitchClient.deliverResult(this);
-//        if (result != null) {
-//            DemoFragment demoFragment = getDemoFragment();
-//            if (demoFragment != null) {
-//                demoFragment.onBrowserSwitchResult(result);
-//            }
-//        }
     }
 
     public void startBrowserSwitch(BrowserSwitchOptions options) throws BrowserSwitchException {

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoActivity.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.FragmentManager;
 
 import com.braintreepayments.api.BrowserSwitchClient;
 import com.braintreepayments.api.BrowserSwitchException;
+import com.braintreepayments.api.BrowserSwitchLauncher;
 import com.braintreepayments.api.BrowserSwitchObserver;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.BrowserSwitchResult;
@@ -19,17 +20,12 @@ public class DemoActivity extends AppCompatActivity {
     private static final String FRAGMENT_TAG = DemoFragment.class.getSimpleName();
     private static final String RETURN_URL_SCHEME = "my-custom-url-scheme-standard";
 
-    @VisibleForTesting
-    BrowserSwitchClient browserSwitchClient = null;
-
-    @VisibleForTesting
-    BrowserSwitchObserver browserSwitchObserver = null;
+    private final BrowserSwitchLauncher browserSwitchLauncher = new BrowserSwitchLauncher();
+    private final BrowserSwitchObserver browserSwitchObserver = new BrowserSwitchObserver();
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        browserSwitchClient = new BrowserSwitchClient();
-        browserSwitchObserver = new BrowserSwitchObserver();
 
         FragmentManager fm = getSupportFragmentManager();
         if (getDemoFragment() == null) {
@@ -46,7 +42,7 @@ public class DemoActivity extends AppCompatActivity {
     }
 
     public void startBrowserSwitch(BrowserSwitchOptions options) throws BrowserSwitchException {
-        browserSwitchClient.start(this, options);
+        browserSwitchLauncher.launch(this, options);
     }
 
     private DemoFragment getDemoFragment() {

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -14,7 +14,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.braintreepayments.api.BrowserSwitchException;
-import com.braintreepayments.api.BrowserSwitchResultListener;
+import com.braintreepayments.api.BrowserSwitchListener;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.BrowserSwitchResult;
 import com.braintreepayments.api.BrowserSwitchStatus;
@@ -22,7 +22,7 @@ import com.braintreepayments.api.BrowserSwitchStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class DemoFragment extends Fragment implements View.OnClickListener, BrowserSwitchResultListener {
+public class DemoFragment extends Fragment implements View.OnClickListener, BrowserSwitchListener {
 
     private static final String TEST_KEY = "testKey";
     private static final String TEST_VALUE = "testValue";

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -101,6 +101,7 @@ public class DemoFragment extends Fragment implements View.OnClickListener, Brow
         mMetadataTextView.setText("");
     }
 
+    @Override
     public void onBrowserSwitchResult(BrowserSwitchResult result) {
         String resultText = null;
         String selectedColorText = "";

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import com.braintreepayments.api.BrowserSwitchException;
+import com.braintreepayments.api.BrowserSwitchResultListener;
 import com.braintreepayments.api.BrowserSwitchOptions;
 import com.braintreepayments.api.BrowserSwitchResult;
 import com.braintreepayments.api.BrowserSwitchStatus;
@@ -21,7 +22,7 @@ import com.braintreepayments.api.BrowserSwitchStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class DemoFragment extends Fragment implements View.OnClickListener {
+public class DemoFragment extends Fragment implements View.OnClickListener, BrowserSwitchResultListener {
 
     private static final String TEST_KEY = "testKey";
     private static final String TEST_VALUE = "testValue";


### PR DESCRIPTION

This PR separates browser switch launch and browser switch result capture logic to allow for a cleaner separation of concerns. It also aims to make it clear that the browser switch initiating activity can be different from the browser switch deep link destination activity.

### Summary of changes

 - Extract `BrowserSwitchLauncher` from `BroswerSwitchClient`
 - Extract `BrowserSwitchObserver` from `BrowserSwitchClient`
 - Deprecate `BrowserSwitchClient`

 ### Checklist

 - [x] Added a changelog entry
