### PR TITLE
Capture Browser Switch Result

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -169,4 +169,24 @@ public class BrowserSwitchClient {
 
         return result;
     }
+
+    BrowserSwitchResult getResultFromCache(@NonNull Context context) {
+        return persistentStore.getActiveResult(context.getApplicationContext());
+    }
+
+    public BrowserSwitchResult deliverResultFromCache(@NonNull Context context) {
+        Context applicationContext = context.getApplicationContext();
+        BrowserSwitchResult result = getResultFromCache(applicationContext);
+        if (result != null) {
+            persistentStore.clearActiveResult(applicationContext);
+        }
+        return result;
+    }
+
+    public void captureResult(@NonNull FragmentActivity activity) {
+        BrowserSwitchResult result = getResult(activity);
+        if (result != null) {
+            persistentStore.putActiveResult(result, activity.getApplicationContext());
+        }
+    }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -56,7 +56,8 @@ public class BrowserSwitchClient {
         persistentStore.putActiveRequest(request, appContext);
 
         if (browserSwitchInspector.deviceHasChromeCustomTabs(appContext)) {
-            customTabsInternalClient.launchUrl(activity, browserSwitchUrl);
+            boolean launchAsNewTask = browserSwitchOptions.isLaunchAsNewTask();
+            customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
         } else {
             Intent launchUrlInBrowser = new Intent(Intent.ACTION_VIEW, browserSwitchUrl);
             activity.startActivity(launchUrlInBrowser);

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -38,7 +38,7 @@ public class BrowserSwitchClient {
      * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
      * with a given set of {@link BrowserSwitchOptions} from an Android activity.
      *
-     * @param activity the activity used to start browser switch
+     * @param activity             the activity used to start browser switch
      * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
      */
     public void start(@NonNull FragmentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {
@@ -79,11 +79,11 @@ public class BrowserSwitchClient {
             errorMessage = "A returnUrlScheme is required.";
         } else if (!browserSwitchInspector.isDeviceConfiguredForDeepLinking(appContext, returnUrlScheme)) {
             errorMessage =
-                "The return url scheme was not set up, incorrectly set up, " +
-                "or more than one Activity on this device defines the same url " +
-                "scheme in it's Android Manifest. See " +
-                "https://github.com/braintree/browser-switch-android for more " +
-                "information on setting up a return url scheme.";
+                    "The return url scheme was not set up, incorrectly set up, " +
+                            "or more than one Activity on this device defines the same url " +
+                            "scheme in it's Android Manifest. See " +
+                            "https://github.com/braintree/browser-switch-android for more " +
+                            "information on setting up a return url scheme.";
         } else if (!browserSwitchInspector.deviceHasBrowser(appContext)) {
             StringBuilder messageBuilder = new StringBuilder("No installed activities can open this URL");
             if (browserSwitchUrl != null) {
@@ -103,10 +103,10 @@ public class BrowserSwitchClient {
 
     /**
      * Deliver a pending browser switch result to an Android activity.
-     *
+     * <p>
      * We recommend you call this method in onResume to receive a browser switch result once your
      * app has re-entered the foreground.
-     *
+     * <p>
      * Cancel and Success results will be delivered only once. If there are no pending
      * browser switch results, this method does nothing.
      *
@@ -124,7 +124,6 @@ public class BrowserSwitchClient {
                 case BrowserSwitchStatus.SUCCESS:
                     // ensure that success result is delivered exactly once
                     persistentStore.clearActiveRequest(appContext);
-                    persistentStore.clearActiveResult(appContext);
                     break;
                 case BrowserSwitchStatus.CANCELED:
                     // ensure that cancellation result is delivered exactly once, but allow for
@@ -140,16 +139,16 @@ public class BrowserSwitchClient {
 
     /**
      * Peek at a pending browser switch result to an Android activity.
-     *
+     * <p>
      * We recommend you call this method in onResume to receive a browser switch result once your
      * app has re-entered the foreground.
-     *
+     * <p>
      * This can be used in place of {@link BrowserSwitchClient#deliverResult(FragmentActivity)} when
      * you want to know the contents of a pending browser switch result before it is delivered.
      *
      * @param activity the activity that received the deep link back into the app
      */
-    public BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
+    BrowserSwitchResult getResult(@NonNull FragmentActivity activity) {
         Intent intent = activity.getIntent();
         Context appContext = activity.getApplicationContext();
 
@@ -164,34 +163,10 @@ public class BrowserSwitchClient {
         Uri deepLinkUrl = intent.getData();
         if (deepLinkUrl != null && request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
-        }
-
-        // check the cache for a "captured" result that has not yet been delivered
-        if (result == null) {
-            result = persistentStore.getActiveResult(appContext);
-        }
-
-        if (result == null && request.getShouldNotifyCancellation()) {
+        } else if (request.getShouldNotifyCancellation()) {
             result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
         }
 
         return result;
-    }
-
-    /**
-     * Capture a browser switch result so that a different activity can consume the result in
-     * the near future.
-     *
-     * {@link BrowserSwitchClient#deliverResult(FragmentActivity)} will return a "cached" browser
-     * switch result as a fallback when the calling activity has not intent data to parse.
-     *
-     * @param activity
-     */
-    public void captureResult(@NonNull FragmentActivity activity) {
-        BrowserSwitchResult result = getResult(activity);
-        if (result != null) {
-            Context appContext = activity.getApplicationContext();
-            persistentStore.putActiveResult(result, appContext);
-        }
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
@@ -20,6 +20,8 @@ public class BrowserSwitchOptions {
     private Uri url;
     private String returnUrlScheme;
 
+    private boolean launchAsNewTask;
+
     /**
      * Set browser switch metadata.
      *
@@ -95,5 +97,14 @@ public class BrowserSwitchOptions {
     @Nullable
     public String getReturnUrlScheme() {
         return returnUrlScheme;
+    }
+
+    public boolean isLaunchAsNewTask() {
+        return launchAsNewTask;
+    }
+
+    public BrowserSwitchOptions launchAsNewTask(boolean launchAsNewTask) {
+        this.launchAsNewTask = launchAsNewTask;
+        return this;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
@@ -16,6 +16,9 @@ class BrowserSwitchPersistentStore {
     @VisibleForTesting
     static final String REQUEST_KEY = "browserSwitch.request";
 
+    @VisibleForTesting
+    static final String RESULT_KEY = "browserSwitch.result";
+
     private static final BrowserSwitchPersistentStore INSTANCE = new BrowserSwitchPersistentStore();
 
     static BrowserSwitchPersistentStore getInstance() {
@@ -48,7 +51,35 @@ class BrowserSwitchPersistentStore {
         }
     }
 
+    void putActiveResult(BrowserSwitchResult result, Context context) {
+        try {
+            PersistentStore.put(RESULT_KEY, result.toJson(), context);
+        } catch (JSONException e) {
+            Log.d(TAG, e.getMessage());
+            Log.d(TAG, Arrays.toString(e.getStackTrace()));
+        }
+    }
+
+    BrowserSwitchResult getActiveResult(Context context) {
+        BrowserSwitchResult request = null;
+
+        String activeResultJSON = PersistentStore.get(RESULT_KEY, context);
+        if (activeResultJSON != null) {
+            try {
+                request = BrowserSwitchResult.fromJson(activeResultJSON);
+            } catch (JSONException e) {
+                Log.d(TAG, e.getMessage());
+                Log.d(TAG, Arrays.toString(e.getStackTrace()));
+            }
+        }
+        return request;
+    }
+
     void clearActiveRequest(Context context) {
         PersistentStore.remove(REQUEST_KEY, context);
+    }
+
+    public void clearActiveResult(Context context) {
+        PersistentStore.remove(RESULT_KEY, context);
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPersistentStore.java
@@ -79,7 +79,7 @@ class BrowserSwitchPersistentStore {
         PersistentStore.remove(REQUEST_KEY, context);
     }
 
-    public void clearActiveResult(Context context) {
+    void clearActiveResult(Context context) {
         PersistentStore.remove(RESULT_KEY, context);
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 
 import androidx.annotation.Nullable;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -11,9 +12,21 @@ import org.json.JSONObject;
  */
 public class BrowserSwitchResult {
 
+    private static final String KEY_STATUS = "status";
+    private static final String KEY_DEEP_LINK_URL = "deepLinkUrl";
+    private static final String KEY_BROWSER_SWITCH_REQUEST = "browserSwitchRequest";
+
     private final int status;
     private final Uri deepLinkUrl;
     private final BrowserSwitchRequest request;
+
+    static BrowserSwitchResult fromJson(String json) throws JSONException {
+        JSONObject jsonObject = new JSONObject(json);
+        int status = jsonObject.getInt(KEY_STATUS);
+        String deepLinkUrl = jsonObject.getString(KEY_DEEP_LINK_URL);
+        String browserSwitchRequest = jsonObject.getString(KEY_BROWSER_SWITCH_REQUEST);
+        return new BrowserSwitchResult(status, BrowserSwitchRequest.fromJson(browserSwitchRequest), Uri.parse(deepLinkUrl));
+    }
 
     BrowserSwitchResult(@BrowserSwitchStatus int status, BrowserSwitchRequest request) {
         this(status, request, null);
@@ -62,5 +75,13 @@ public class BrowserSwitchResult {
     @Nullable
     public Uri getDeepLinkUrl() {
         return deepLinkUrl;
+    }
+
+    public String toJson() throws JSONException {
+        JSONObject result = new JSONObject();
+        result.put(KEY_STATUS, status);
+        result.put(KEY_DEEP_LINK_URL, deepLinkUrl.toString());
+        result.put(KEY_BROWSER_SWITCH_REQUEST, request.toJson());
+        return result.toString();
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.api;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 
 import androidx.annotation.VisibleForTesting;
@@ -19,8 +20,11 @@ class ChromeCustomTabsInternalClient {
         this.customTabsIntentBuilder = builder;
     }
 
-    void launchUrl(Context context, Uri url) {
+    void launchUrl(Context context, Uri url, boolean launchAsNewTask) {
         CustomTabsIntent customTabsIntent = customTabsIntentBuilder.build();
+        if (launchAsNewTask) {
+            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        }
         customTabsIntent.launchUrl(context, url);
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -14,7 +14,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowActivity;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,7 +76,7 @@ public class BrowserSwitchClientUnitTest {
                 .metadata(metadata);
         sut.start(activity, options);
 
-        verify(customTabsInternalClient).launchUrl(activity, browserSwitchDestinationUrl);
+        verify(customTabsInternalClient).launchUrl(activity, browserSwitchDestinationUrl, false);
         verify(activity, never()).startActivity(any(Intent.class));
 
         ArgumentCaptor<BrowserSwitchRequest> captor =
@@ -107,7 +106,7 @@ public class BrowserSwitchClientUnitTest {
                 .metadata(metadata);
         sut.start(activity, options);
 
-        verify(customTabsInternalClient, never()).launchUrl(activity, browserSwitchDestinationUrl);
+        verify(customTabsInternalClient, never()).launchUrl(activity, browserSwitchDestinationUrl, false);
 
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
         verify(activity).startActivity(intentCaptor.capture());

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchResultUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchResultUnitTest.java
@@ -1,0 +1,9 @@
+package com.braintreepayments.api;
+
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class BrowserSwitchResultUnitTest {
+
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
@@ -31,7 +31,7 @@ public class ChromeCustomTabsInternalClientUnitTest {
 
         Uri url = mock(Uri.class);
         Context context = mock(Context.class);
-        sut.launchUrl(context, url, launchAsNewTask);
+        sut.launchUrl(context, url, false);
 
         verify(customTabsIntent).launchUrl(context, url);
     }

--- a/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.java
@@ -31,7 +31,7 @@ public class ChromeCustomTabsInternalClientUnitTest {
 
         Uri url = mock(Uri.class);
         Context context = mock(Context.class);
-        sut.launchUrl(context, url);
+        sut.launchUrl(context, url, launchAsNewTask);
 
         verify(customTabsIntent).launchUrl(context, url);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoFragment.java
@@ -66,6 +66,7 @@ public class DemoFragment extends Fragment implements View.OnClickListener {
                 .metadata(metadata)
                 .requestCode(1)
                 .url(url)
+                .launchAsNewTask(true)
                 .returnUrlScheme(getReturnUrlScheme());
 
         try {


### PR DESCRIPTION
### Summary of changes

 - Add BrowserSwitchClient#captureResult() method to capture a browser switch result into persistent storage
 - Add BrowserSwitchClient#deliverResultFromCache() method to deliver a previously capture browser switch result 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @sshropshire 
