### PR TITLE
Prevent Browser Switch Results From Being Parsed Twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Fix issue that caused browser switch results to be parsed multiple times
+
 ## 2.3.0
 
 * Add BrowserSwitchClient#getResult() method to peek at a pending browser switch result before it is delivered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Fix issue that caused browser switch results to be parsed multiple times
+* Fix issue that causes successful deep links to be parsed multiple times
 
 ## 2.3.0
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -118,6 +118,10 @@ public class BrowserSwitchClient {
                 case BrowserSwitchStatus.SUCCESS:
                     // ensure that success result is delivered exactly once
                     persistentStore.clearActiveRequest(appContext);
+
+                    // clear activity intent to prevent the browser switch result
+                    // from being parsed again
+                    activity.setIntent(null);
                     break;
                 case BrowserSwitchStatus.CANCELED:
                     // ensure that cancellation result is delivered exactly once, but allow for

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -119,8 +119,7 @@ public class BrowserSwitchClient {
                     // ensure that success result is delivered exactly once
                     persistentStore.clearActiveRequest(appContext);
 
-                    // clear activity intent to prevent the browser switch result
-                    // from being parsed again
+                    // clear activity intent to prevent deep links from being parsed multiple times
                     activity.setIntent(null);
                     break;
                 case BrowserSwitchStatus.CANCELED:

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -240,6 +240,7 @@ public class BrowserSwitchClientUnitTest {
         assertSame(deepLinkUrl, result.getDeepLinkUrl());
 
         verify(persistentStore).clearActiveRequest(applicationContext);
+        verify(activity).setIntent(null);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes

 - Fix issue that causes successful deep links to be parsed multiple times

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mattwylder
- @sshropshire
