### PR TITLE
Check if Activity is Finishing Before Browser Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Check if a pending browser switch request exists before delivering a browser switch result instead of setting Activity intent to null (fix for #634)
+* Check if a pending browser switch request exists before delivering a browser switch result instead of setting Activity intent to null
+* Fix issue that causes a browser switch to start while the host Activity is finishing
 
 ## 2.3.1
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -57,7 +57,11 @@ public class BrowserSwitchClient {
                 new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme, true);
         persistentStore.putActiveRequest(request, appContext);
 
-        if (browserSwitchInspector.deviceHasChromeCustomTabs(appContext)) {
+        if (activity.isFinishing()) {
+            String activityFinishingMessage =
+                "Unable to start browser switch while host Activity is finishing.";
+            throw new BrowserSwitchException(activityFinishingMessage);
+        } else if (browserSwitchInspector.deviceHasChromeCustomTabs(appContext)) {
             boolean launchAsNewTask = browserSwitchOptions.isLaunchAsNewTask();
             customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
         } else {

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -65,6 +65,31 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
+    public void start_whenActivityIsFinishing_throwsException() {
+        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
+        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
+        when(browserSwitchInspector.deviceHasChromeCustomTabs(applicationContext)).thenReturn(true);
+
+        when(activity.isFinishing()).thenReturn(true);
+
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject metadata = new JSONObject();
+        BrowserSwitchOptions options = new BrowserSwitchOptions()
+                .requestCode(123)
+                .url(browserSwitchDestinationUrl)
+                .returnUrlScheme("return-url-scheme")
+                .metadata(metadata);
+
+        try {
+            sut.start(activity, options);
+            fail("should fail");
+        } catch (BrowserSwitchException e) {
+            assertEquals(e.getMessage(), "Unable to start browser switch while host Activity is finishing.");
+        }
+    }
+
+    @Test
     public void start_whenChromeCustomTabsSupported_createsBrowserSwitchIntentAndInitiatesBrowserSwitch() throws BrowserSwitchException {
         when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);


### PR DESCRIPTION
### Summary of changes

 - Fix issue that causes a browser switch to start while the host Activity is finishing.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
