### PR TITLE
Keep Activity Intent After Successful Browser Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Check if a pending browser switch request exists before delivering a browser switch result instead of setting Activity intent to null (fix for #634)
+
 ## 2.3.1
 
 * Fix issue that causes successful deep links to be parsed multiple times

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -218,29 +218,19 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void deliverResult_whenDeepLinkUrlExistsAndReturnUrlSchemeMatches_clearsResultStoreAndNotifiesResultSUCCESS() {
+    public void deliverResult_whenDeepLinkUrlExistsAndReturnUrlSchemeMatchesAndNoPendingRequest_returnsNull() {
         when(activity.getApplicationContext()).thenReturn(applicationContext);
 
         Uri deepLinkUrl = Uri.parse("return-url-scheme://test");
         Intent deepLinkIntent = new Intent().setData(deepLinkUrl);
         when(activity.getIntent()).thenReturn(deepLinkIntent);
 
-        JSONObject requestMetadata = new JSONObject();
-        BrowserSwitchRequest request = new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "return-url-scheme", false);
-        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(request);
+        when(persistentStore.getActiveRequest(applicationContext)).thenReturn(null);
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
         BrowserSwitchResult result = sut.deliverResult(activity);
 
-        assertNotNull(result);
-        assertEquals(123, result.getRequestCode());
-        assertSame(browserSwitchDestinationUrl, result.getRequestUrl());
-        assertEquals(BrowserSwitchStatus.SUCCESS, result.getStatus());
-        assertSame(requestMetadata, result.getRequestMetadata());
-        assertSame(deepLinkUrl, result.getDeepLinkUrl());
-
-        verify(persistentStore).clearActiveRequest(applicationContext);
-        verify(activity).setIntent(null);
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION

### Summary of changes

 - Check if a pending browser switch request exists before delivering a browser switch result instead of setting Activity intent to `null` (fix for #634)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
