### PR TITLE
Remove Jetifier From Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Remove Jetifier
+
 ## 2.3.2
 
 * Check if a pending browser switch request exists before delivering a browser switch result instead of setting Activity intent to null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-* Remove Jetifier
+* Remove Jetifier now that AndroidX is fully supported
 
 ## 2.3.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,1 @@
 android.useAndroidX=true
-android.enableJetifier=true
-


### PR DESCRIPTION
### Summary of changes

 - Removing Jetifier from project. We are fully migrated onto `androidx.*`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
