### PR TITLE
Remove Browser Check and Officially Support API Version 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unreleased
 
 * Remove Jetifier now that AndroidX is fully supported
+* Upgrade `compileSdkVersion` and `targetSdkVersion` to API 33
+* Remove unnecessary assertion for a browser application on the device
 
 ## 2.3.2
 

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -28,26 +28,26 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.fragment:fragment:1.2.5'
-    implementation 'androidx.browser:browser:1.0.0'
+    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.fragment:fragment:1.5.7'
+    implementation 'androidx.browser:browser:1.5.0'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.7'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.7'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
-    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
+    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
+    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.1'
 
     testImplementation 'org.robolectric:robolectric:4.7.3'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'org.mockito:mockito-android:2.28.2'
-    androidTestImplementation "androidx.fragment:fragment-testing:1.2.5"
+    androidTestImplementation "androidx.fragment:fragment-testing:1.5.7"
 }
 
 // region signing and publishing

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -85,9 +85,6 @@ public class BrowserSwitchClient {
             errorMessage = activity.getString(R.string.error_return_url_required);
         } else if (!browserSwitchInspector.isDeviceConfiguredForDeepLinking(appContext, returnUrlScheme)) {
             errorMessage = activity.getString(R.string.error_device_not_configured_for_deep_link);
-        } else if (!browserSwitchInspector.deviceHasBrowser(appContext)) {
-            String urlString = (browserSwitchUrl != null) ? browserSwitchUrl.toString() : "";
-            errorMessage = activity.getString(R.string.error_browser_not_found, urlString);
         }
 
         if (errorMessage != null) {

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -201,27 +201,6 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void start_whenNoActivityFoundCanOpenURL_throwsError() {
-        when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(false);
-        when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
-
-        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
-
-        JSONObject metadata = new JSONObject();
-        BrowserSwitchOptions options = new BrowserSwitchOptions()
-                .requestCode(123)
-                .url(browserSwitchDestinationUrl)
-                .returnUrlScheme("return-url-scheme")
-                .metadata(metadata);
-        try {
-            sut.start(activity, options);
-            fail("should fail");
-        } catch (BrowserSwitchException e) {
-            assertEquals("No installed activities can open this URL: https://example.com/browser_switch_destination", e.getMessage());
-        }
-    }
-
-    @Test
     public void start_whenNoReturnUrlSchemeSet_throwsError() {
         when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ plugins {
 
 version '2.3.3-SNAPSHOT'
 ext {
-    compileSdkVersion = 31
+    compileSdkVersion = 33
     minSdkVersion = 21
-    targetSdkVersion = 31
+    targetSdkVersion = 33
     versionCode = 64
     versionName = version
 }


### PR DESCRIPTION
### Summary of changes

* Upgrade `compileSdkVersion` and `targetSdkVersion` to API 33
* Remove unnecessary assertion for a browser application on the device

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
