### PR TITLE
Parse Browser Switch Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Remove Jetifier now that AndroidX is fully supported
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 33
 * Remove unnecessary assertion for a browser application on the device
+* Add `BrowserSwitchClient#parseResult()` method
+* Add `BrowserSwitchClient#clearActiveRequests()` method
 
 ## 2.3.2
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -176,7 +176,7 @@ public class BrowserSwitchClient {
      * @return
      */
     @Nullable
-    BrowserSwitchResult parseResult(@NonNull Context context, int requestCode, @Nullable Intent intent) {
+    public BrowserSwitchResult parseResult(@NonNull Context context, int requestCode, @Nullable Intent intent) {
         BrowserSwitchResult result = null;
         if (intent != null) {
             BrowserSwitchRequest request =
@@ -199,7 +199,7 @@ public class BrowserSwitchClient {
      *
      * @param context Context for storage to be cleared
      */
-    void clearActiveRequests(@NonNull Context context) {
+    public void clearActiveRequests(@NonNull Context context) {
         persistentStore.clearActiveRequest(context.getApplicationContext());
     }
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -73,7 +73,6 @@ public class BrowserSwitchClient {
     void assertCanPerformBrowserSwitch(FragmentActivity activity, BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {
         Context appContext = activity.getApplicationContext();
 
-        Uri browserSwitchUrl = browserSwitchOptions.getUrl();
         int requestCode = browserSwitchOptions.getRequestCode();
         String returnUrlScheme = browserSwitchOptions.getReturnUrlScheme();
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -178,15 +178,13 @@ public class BrowserSwitchClient {
     @Nullable
     public BrowserSwitchResult parseResult(@NonNull Context context, int requestCode, @Nullable Intent intent) {
         BrowserSwitchResult result = null;
-        if (intent != null) {
+        if (intent != null && intent.getData() != null) {
             BrowserSwitchRequest request =
                     persistentStore.getActiveRequest(context.getApplicationContext());
             if (request != null && request.getRequestCode() == requestCode) {
                 Uri deepLinkUrl = intent.getData();
-                if (deepLinkUrl != null && request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
+                if (request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
                     result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
-                } else if (request.getShouldNotifyCancellation()) {
-                    result = new BrowserSwitchResult(BrowserSwitchStatus.CANCELED, request);
                 }
             }
         }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -359,7 +359,7 @@ public class BrowserSwitchClientUnitTest {
         sut.captureResult(activity);
 
         ArgumentCaptor<BrowserSwitchResult> captor =
-            ArgumentCaptor.forClass(BrowserSwitchResult.class);
+                ArgumentCaptor.forClass(BrowserSwitchResult.class);
         verify(persistentStore).putActiveResult(captor.capture(), same(applicationContext));
 
         BrowserSwitchResult result = captor.getValue();
@@ -411,5 +411,75 @@ public class BrowserSwitchClientUnitTest {
 
         assertSame(cachedResult, actualResult);
         verify(persistentStore).removeAll(applicationContext);
+    }
+
+    @Test
+    public void parseResult_whenActiveRequestMatchesRequestCodeAndDeepLinkResultURLScheme_returnsBrowserSwitchSuccessResult() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+            new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
+        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
+
+        Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
+        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+
+        assertNotNull(browserSwitchResult);
+        assertEquals(BrowserSwitchStatus.SUCCESS, browserSwitchResult.getStatus());
+        assertEquals(deepLinkUrl, browserSwitchResult.getDeepLinkUrl());
+    }
+
+    @Test
+    public void parseResult_whenActiveRequestMatchesRequestCodeAndDeepLinkResultURLSchemeDoesntMatch_returnsNull() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
+        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
+
+        Uri deepLinkUrl = Uri.parse("a-different-url-scheme://success");
+        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+
+        assertNull(browserSwitchResult);
+    }
+
+    @Test
+    public void parseResult_whenActiveRequestDoesntMatchRequestCode_returnsNull() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(456, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
+        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
+
+        Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
+        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+
+        assertNull(browserSwitchResult);
+    }
+
+    @Test
+    public void parseResult_whenNoActiveRequestExists_returnsNull() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(null);
+
+        Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
+        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+
+        assertNull(browserSwitchResult);
+    }
+
+    @Test
+    public void parseResult_whenIntentIsNull_returnsNull() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, null);
+        assertNull(browserSwitchResult);
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -482,4 +482,12 @@ public class BrowserSwitchClientUnitTest {
         BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, null);
         assertNull(browserSwitchResult);
     }
+
+    @Test
+    public void clearActiveRequests_forwardsInvocationToPersistantStore() {
+        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
+
+        sut.clearActiveRequests(applicationContext);
+        verify(persistentStore).clearActiveRequest(applicationContext);
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
         maven {
             url = "https://plugins.gradle.org/m2/"
         }
@@ -28,8 +28,8 @@ ext {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
### Summary of changes

* This PR takes an alternative approach to browser switching through the following methods
  * Add `BrowserSwitchClient#parseResult()` method
  * Add `BrowserSwitchClient#clearActiveRequests()` method
* Unlike `deliverResult()`, `parseResult()` does not mutate persistent storage
* `clearActiveRequests()` puts the responsibility on the caller to guard against delivery of a browser switch result more than one time 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
