### PR TITLE
Remove Kotlin BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Revert `androidx.annotation:annotation` dependency to version `1.2.0`
+* Revert `androidx.appcompat:appcompat` dependency to version `1.3.1`
+
 ## 2.4.0
 
 * Remove Jetifier now that AndroidX is fully supported

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -34,11 +34,11 @@ dependencies {
 
     testImplementation deps.junit
     testImplementation deps.mockitoCore
-
     testImplementation deps.jsonassert
     testImplementation deps.robolectric
 
     // TODO: remove powermock
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -28,30 +28,20 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.fragment:fragment:1.5.7'
-    implementation 'androidx.browser:browser:1.5.0'
+    implementation deps.annotation
+    implementation deps.appcompat
+    implementation deps.browser
 
-    // Ref: https://kotlinlang.org/docs/whatsnew18.html#usage-of-the-latest-kotlin-stdlib-version-in-transitive-dependencies
-    // TODO: remove once we migrate to Kotlin
-    implementation platform("org.jetbrains.kotlin:kotlin-bom:1.8.0")
+    testImplementation deps.junit
+    testImplementation deps.mockitoCore
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
+    testImplementation deps.jsonassert
+    testImplementation deps.robolectric
+
+    // TODO: remove powermock
     testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
     testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
-    testImplementation 'org.skyscreamer:jsonassert:1.5.1'
-
-    testImplementation 'org.robolectric:robolectric:4.7.3'
-
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test:runner:1.5.2'
-    androidTestImplementation 'org.mockito:mockito-android:2.28.2'
-    androidTestImplementation "androidx.fragment:fragment-testing:1.5.7"
 }
 
 // region signing and publishing

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.deps = [
         'annotation'  : 'androidx.annotation:annotation:1.2.0',
         'appcompat'   : 'androidx.appcompat:appcompat:1.3.1',
-        'browser'     : 'androidx.browser:browser:1.3.0',
+        'browser'     : 'androidx.browser:browser:1.5.0',
 
         // test dependencies
         'junit'       : 'junit:junit:4.13.2',

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,19 @@ buildscript {
             url = "https://plugins.gradle.org/m2/"
         }
     }
+
+    ext.deps = [
+        'annotation'  : 'androidx.annotation:annotation:1.2.0',
+        'appcompat'   : 'androidx.appcompat:appcompat:1.3.1',
+        'browser'     : 'androidx.browser:browser:1.3.0',
+
+        // test dependencies
+        'junit'       : 'junit:junit:4.13.2',
+        'mockitoCore' : 'org.mockito:mockito-core:3.3.3',
+        'jsonassert'  : 'org.skyscreamer:jsonassert:1.5.1',
+        'robolectric' : 'org.robolectric:robolectric:4.7.3'
+    ]
+
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -23,9 +23,9 @@ android {
 
 dependencies {
     implementation project(':browser-switch')
-    implementation "androidx.annotation:annotation:1.6.0"
-    implementation "androidx.appcompat:appcompat:1.6.1"
-    implementation "androidx.fragment:fragment:1.5.7"
+    implementation "androidx.annotation:annotation:1.3.0"
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "androidx.fragment:fragment:1.3.6"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 06 09:17:36 CDT 2022
+#Mon Jul 17 09:55:05 CDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary of changes

 - Remove Kotlin BOM platform dependency
 - Revert `androidx.annotation:annotation` dependency to version `1.2.0`
 - Revert `androidx.appcompat:appcompat` dependency to version `1.3.1`

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 
