### PR TITLE
Fix Return URL Scheme Matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # browser-switch-android Release Notes
 
+## unreleased
+* Fix issue where URL scheme matching is case sensitive
+
 ## 2.5.0
 
 * Revert `androidx.annotation:annotation` dependency to version `1.2.0`

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -67,6 +67,6 @@ class BrowserSwitchRequest {
     }
 
     boolean matchesDeepLinkUrlScheme(@NonNull Uri url) {
-        return url.getScheme().equals(returnUrlScheme);
+        return url.getScheme() != null && url.getScheme().equalsIgnoreCase(returnUrlScheme);
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -1,5 +1,10 @@
 package com.braintreepayments.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import android.net.Uri;
 
 import org.json.JSONException;
@@ -8,11 +13,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class BrowserSwitchRequestUnitTest {
@@ -110,5 +110,34 @@ public class BrowserSwitchRequestUnitTest {
 
         assertTrue(restored.matchesDeepLinkUrlScheme(Uri.parse("my-return-url-scheme://test")));
         assertFalse(restored.matchesDeepLinkUrlScheme(Uri.parse("another-return-url-scheme://test")));
+    }
+
+    @Test
+    public void matchesDeepLinkUrlScheme_whenSameSchemeDifferentCase_returnsTrue() throws JSONException {
+        String json = "{\n" +
+                "  \"requestCode\": 123,\n" +
+                "  \"url\": \"https://example.com\",\n" +
+                "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": false,\n" +
+                "  \"metadata\": {\n" +
+                "    \"testKey\": \"testValue\"" +
+                "  }" +
+                "}";
+        BrowserSwitchRequest request = BrowserSwitchRequest.fromJson(json);
+        assertTrue(request.matchesDeepLinkUrlScheme(Uri.parse("My-Return-Url-Scheme://example.com")));
+    }
+    @Test
+    public void matchesDeepLinkUrlScheme_whenDifferentScheme_returnsFalse() throws JSONException {
+        String json = "{\n" +
+                "  \"requestCode\": 123,\n" +
+                "  \"url\": \"https://example.com\",\n" +
+                "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+                "  \"shouldNotify\": false,\n" +
+                "  \"metadata\": {\n" +
+                "    \"testKey\": \"testValue\"" +
+                "  }" +
+                "}";
+        BrowserSwitchRequest request = BrowserSwitchRequest.fromJson(json);
+        assertFalse(request.matchesDeepLinkUrlScheme(Uri.parse("not-my-return-url-scheme://example.com")));
     }
 }


### PR DESCRIPTION
### Summary of changes

 - Match URL schemes ignoring case to fix issues where merchant integrations are not working properly if their return URL scheme has capitalization. 

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
