### PR TITLE
Update to use Gradle Nexus Publish Plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,16 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
   # Run unit tests after a successful build
-#  unit_test_browser_switch:
-#    name: Unit Test Browser Switch
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Setup Java
-#        uses: ./.github/actions/setup_java
-#      - name: Run Unit Tests
-#        run: ./ci unit_tests
+  unit_test_browser_switch:
+    name: Unit Test Browser Switch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
+      - name: Run Unit Tests
+        run: ./ci unit_tests
 
   # Publish after successful build and unit tests
   publish_browser_switch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,50 +62,50 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
-#  release_finished:
-#    needs: [ publish_browser_switch ]
-#    name: Release Finished
-#    runs-on: ubuntu-latest
-#    steps:
-#      - run: echo "Release finished"
-#
-#  bump_version:
-#    needs: [ release_finished ]
-#    name: Bump Version
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Set GitHub User
-#        run: ./ci set_github_user_to_braintreeps
-#      - name: Update Version
-#        run: |
-#          ./ci update_version ${{ github.event.inputs.version }}
-#          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
-#
-#          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
-#          ./ci increment_demo_app_version_code
-#
-#          git commit -am 'Prepare for development'
-#          git push origin master ${{ github.event.inputs.version }}
-#
-#  create_github_release:
-#    needs: [ bump_version ]
-#    name: Create GitHub Release
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Repository
-#        uses: actions/checkout@v2
-#      - name: Save changelog entries to a file
-#        run: ./ci get_latest_changelog_entries > changelog_entries.md
-#      - name: Create GitHub Release
-#        id: create_release
-#        uses: actions/create-release@v1
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          tag_name: ${{ github.event.inputs.version }}
-#          release_name: ${{ github.event.inputs.version }}
-#          body_path: changelog_entries.md
-#          draft: false
-#          prerelease: false
+  release_finished:
+    needs: [ publish_browser_switch ]
+    name: Release Finished
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Release finished"
+
+  bump_version:
+    needs: [ release_finished ]
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set GitHub User
+        run: ./ci set_github_user_to_braintreeps
+      - name: Update Version
+        run: |
+          ./ci update_version ${{ github.event.inputs.version }}
+          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
+
+          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
+          ./ci increment_demo_app_version_code
+
+          git commit -am 'Prepare for development'
+          git push origin master ${{ github.event.inputs.version }}
+
+  create_github_release:
+    needs: [ bump_version ]
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Save changelog entries to a file
+        run: ./ci get_latest_changelog_entries > changelog_entries.md
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body_path: changelog_entries.md
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,16 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
   # Run unit tests after a successful build
-  unit_test_browser_switch:
-    name: Unit Test Browser Switch
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Setup Java
-        uses: ./.github/actions/setup_java
-      - name: Run Unit Tests
-        run: ./ci unit_tests
+#  unit_test_browser_switch:
+#    name: Unit Test Browser Switch
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Setup Java
+#        uses: ./.github/actions/setup_java
+#      - name: Run Unit Tests
+#        run: ./ci unit_tests
 
   # Publish after successful build and unit tests
   publish_browser_switch:
@@ -62,50 +62,50 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
-  release_finished:
-    needs: [ publish_browser_switch ]
-    name: Release Finished
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Release finished"
-
-  bump_version:
-    needs: [ release_finished ]
-    name: Bump Version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set GitHub User
-        run: ./ci set_github_user_to_braintreeps
-      - name: Update Version
-        run: |
-          ./ci update_version ${{ github.event.inputs.version }}
-          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
-
-          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
-          ./ci increment_demo_app_version_code
-
-          git commit -am 'Prepare for development'
-          git push origin master ${{ github.event.inputs.version }}
-
-  create_github_release:
-    needs: [ bump_version ]
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Save changelog entries to a file
-        run: ./ci get_latest_changelog_entries > changelog_entries.md
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          release_name: ${{ github.event.inputs.version }}
-          body_path: changelog_entries.md
-          draft: false
-          prerelease: false
+#  release_finished:
+#    needs: [ publish_browser_switch ]
+#    name: Release Finished
+#    runs-on: ubuntu-latest
+#    steps:
+#      - run: echo "Release finished"
+#
+#  bump_version:
+#    needs: [ release_finished ]
+#    name: Bump Version
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set GitHub User
+#        run: ./ci set_github_user_to_braintreeps
+#      - name: Update Version
+#        run: |
+#          ./ci update_version ${{ github.event.inputs.version }}
+#          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
+#
+#          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
+#          ./ci increment_demo_app_version_code
+#
+#          git commit -am 'Prepare for development'
+#          git push origin master ${{ github.event.inputs.version }}
+#
+#  create_github_release:
+#    needs: [ bump_version ]
+#    name: Create GitHub Release
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Save changelog entries to a file
+#        run: ./ci get_latest_changelog_entries > changelog_entries.md
+#      - name: Create GitHub Release
+#        id: create_release
+#        uses: actions/create-release@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          tag_name: ${{ github.event.inputs.version }}
+#          release_name: ${{ github.event.inputs.version }}
+#          body_path: changelog_entries.md
+#          draft: false
+#          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Publish Browser Switch
         run: ./ci publish release
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,50 +62,50 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
 
-  release_finished:
-    needs: [ publish_browser_switch ]
-    name: Release Finished
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Release finished"
-
-  bump_version:
-    needs: [ release_finished ]
-    name: Bump Version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set GitHub User
-        run: ./ci set_github_user_to_braintreeps
-      - name: Update Version
-        run: |
-          ./ci update_version ${{ github.event.inputs.version }}
-          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
-
-          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
-          ./ci increment_demo_app_version_code
-
-          git commit -am 'Prepare for development'
-          git push origin master ${{ github.event.inputs.version }}
-
-  create_github_release:
-    needs: [ bump_version ]
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Save changelog entries to a file
-        run: ./ci get_latest_changelog_entries > changelog_entries.md
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          release_name: ${{ github.event.inputs.version }}
-          body_path: changelog_entries.md
-          draft: false
-          prerelease: false
+#  release_finished:
+#    needs: [ publish_browser_switch ]
+#    name: Release Finished
+#    runs-on: ubuntu-latest
+#    steps:
+#      - run: echo "Release finished"
+#
+#  bump_version:
+#    needs: [ release_finished ]
+#    name: Bump Version
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Set GitHub User
+#        run: ./ci set_github_user_to_braintreeps
+#      - name: Update Version
+#        run: |
+#          ./ci update_version ${{ github.event.inputs.version }}
+#          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
+#
+#          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
+#          ./ci increment_demo_app_version_code
+#
+#          git commit -am 'Prepare for development'
+#          git push origin master ${{ github.event.inputs.version }}
+#
+#  create_github_release:
+#    needs: [ bump_version ]
+#    name: Create GitHub Release
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Save changelog entries to a file
+#        run: ./ci get_latest_changelog_entries > changelog_entries.md
+#      - name: Create GitHub Release
+#        id: create_release
+#        uses: actions/create-release@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          tag_name: ${{ github.event.inputs.version }}
+#          release_name: ${{ github.event.inputs.version }}
+#          body_path: changelog_entries.md
+#          draft: false
+#          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # browser-switch-android Release Notes
 
-## unreleased
-
-* Update publish plugin
-
 ## 2.6.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Update publish plugin
+
 ## 2.6.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Upgrade publish plugin
+* 
 ## 2.6.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # browser-switch-android Release Notes
 
-## unreleased
-
-* Upgrade publish plugin
-* 
 ## 2.6.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -38,22 +38,6 @@ dependencies {
 
 // region signing and publishing
 
-task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    failOnError false
-}
-
-task javadocsJar(type: Jar, dependsOn: javadocs) {
-    archiveClassifier.set('javadoc')
-    from javadocs.destinationDir
-}
-
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
 project.ext.name = "browser-switch"
 project.ext.pom_name = "browser-switch"
 project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -56,7 +56,6 @@ task sourcesJar(type: Jar) {
 
 project.ext.name = "browser-switch"
 project.ext.pom_name = "browser-switch"
-project.ext.group_name = "com.braintreepayments.api"
 project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."
 
 apply from: rootProject.file("gradle/gradle-publish.gradle")

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 project.ext.name = "browser-switch"
 project.ext.pom_name = "browser-switch"
 project.ext.group_id = "com.braintreepayments.api"
+project.ext.version = rootProject.version
 project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."
 
 apply from: rootProject.file("gradle/gradle-publish.gradle")

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
 project.ext.name = "browser-switch"
 project.ext.pom_name = "browser-switch"
+project.ext.group_id = "com.braintreepayments.api"
 project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."
 
 apply from: rootProject.file("gradle/gradle-publish.gradle")

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -56,6 +56,7 @@ task sourcesJar(type: Jar) {
 
 project.ext.name = "browser-switch"
 project.ext.pom_name = "browser-switch"
+project.ext.group_name = "com.braintreepayments.api"
 project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."
 
 apply from: rootProject.file("gradle/gradle-publish.gradle")

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'com.android.library'
-    id 'maven-publish'
-    id 'signing'
 }
 
 android {
@@ -56,57 +54,11 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-signing {
-    required {
-        !version.endsWith("SNAPSHOT")
-    }
-    sign publishing.publications
-}
+project.ext.name = "browser-switch"
+project.ext.pom_name = "browser-switch"
+project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page."
 
-publishing {
-    publications {
-        release(MavenPublication) {
-            afterEvaluate {
-                from components.release
-            }
-
-            groupId = 'com.braintreepayments.api'
-            artifactId = 'browser-switch'
-            version = rootProject.versionName
-
-            artifact sourcesJar
-            artifact javadocsJar
-
-            pom {
-                name = 'browser-switch'
-                packaging = 'aar'
-                description = 'Android Browser Switch makes it easy to open a url in a browser or Chrome Custom Tab and receive a response as the result of user interaction, either cancel or response data from the web page.'
-                url = 'https://github.com/braintree/browser-switch-android'
-
-                scm {
-                    url = 'scm:git@github.com:braintree/browser-switch-android.git'
-                    connection = 'scm:git@github.com:braintree/browser-switch-android.git'
-                    developerConnection = 'scm:git@github.com:braintree/browser-switch-android.git'
-                }
-
-                developers {
-                    developer {
-                        id = 'devs'
-                        name = 'Braintree Payments'
-                    }
-                }
-
-                licenses {
-                    license {
-                        name = 'MIT'
-                        url = 'http://opensource.org/licenses/MIT'
-                        distribution = 'repo'
-                    }
-                }
-            }
-        }
-    }
-}
+apply from: rootProject.file("gradle/gradle-publish.gradle")
 
 // endregion
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 version = '2.6.1-SNAPSHOT'
-group = "com.braintreepayments.api"
+group = "com.braintreepayments"
 ext {
     compileSdkVersion = 34
     minSdkVersion = 21

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ plugins {
 }
 
 version = '2.6.1-SNAPSHOT'
-group = "com.braintreepayments"
+group = "com.braintreepayments.api"
 ext {
     compileSdkVersion = 34
     minSdkVersion = 21

--- a/build.gradle
+++ b/build.gradle
@@ -38,22 +38,22 @@ ext {
     versionName = version
 }
 
-ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
-ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD') ?: ''
-ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
-
 allprojects {
     repositories {
         mavenCentral()
         google()
+
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 }
 
 nexusPublishing {
     repositories {
         sonatype {
-            username = System.getenv('SONATYPE_USERNAME')
-            password = System.getenv('SONATYPE_PASSWORD')
+            username = System.getenv('SONATYPE_NEXUS_USERNAME') ?: ''
+            password = System.getenv('SONATYPE_NEXUS_PASSWORD') ?: ''
         }
     }
     transitionCheckOptions {

--- a/ci
+++ b/ci
@@ -53,7 +53,7 @@ case $command_name in
     release_type="$2"
     if [ "${release_type}" == "release" ]; then
       # publish release
-      ./gradlew --stacktrace clean :browser-switch:publishToSonatype closeAndReleaseSonatypeStagingRepository
+      ./gradlew --stacktrace clean :browser-switch:publishToSonatype
     else
       # publish SNAPSHOT
       ./gradlew --stacktrace clean :browser-switch:publishToSonatype

--- a/ci
+++ b/ci
@@ -53,7 +53,7 @@ case $command_name in
     release_type="$2"
     if [ "${release_type}" == "release" ]; then
       # publish release
-      ./gradlew --stacktrace clean :browser-switch:publishToSonatype
+      ./gradlew --stacktrace clean :browser-switch:publishToSonatype closeAndReleaseSonatypeStagingRepository
     else
       # publish SNAPSHOT
       ./gradlew --stacktrace clean :browser-switch:publishToSonatype

--- a/ci
+++ b/ci
@@ -44,8 +44,8 @@ case $command_name in
     ;;
   publish)
     # Ref: https://nickjanetakis.com/blog/prevent-unset-variables-in-your-shell-bash-scripts-with-set-nounset
-    [ -n "${SONATYPE_USERNAME}" ]    || (echo "::error:: SONATYPE_USERNAME env variable not set" && exit 1)
-    [ -n "${SONATYPE_PASSWORD}" ]    || (echo "::error:: SONATYPE_PASSWORD env variable not set" && exit 1)
+    [ -n "${SONATYPE_NEXUS_USERNAME}" ]    || (echo "::error:: SONATYPE_NEXUS_USERNAME env variable not set" && exit 1)
+    [ -n "${SONATYPE_NEXUS_PASSWORD}" ]    || (echo "::error:: SONATYPE_NEXUS_PASSWORD env variable not set" && exit 1)
     [ -n "${SIGNING_KEY_ID}" ]       || (echo "::error:: SIGNING_KEY_ID env variable not set" && exit 1)
     [ -n "${SIGNING_KEY_PASSWORD}" ] || (echo "::error:: SIGNING_KEY_PASSWORD env variable not set" && exit 1)
     [ -n "${SIGNING_KEY_FILE}" ]     || (echo "::error:: SIGNING_KEY_FILE env variable not set" && exit 1)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,19 @@ android.useAndroidX=true
 
 # Ref: https://stackoverflow.com/a/50673210
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+POM_PACKAGING=aar
+
+POM_URL=https://github.com/braintree/browser-switch-android
+
+POM_SCM_URL=scm:git@github.com:braintree/browser-switch-android.git
+POM_SCM_CONNECTION=scm:git@github.com:braintree/browser-switch-android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:braintree/browser-switch-android.git
+
+POM_LICENSE_NAME=MIT
+POM_LICENSE_URL=http://opensource.org/licenses/MIT
+POM_LICENSE_DISTRIBUTION=repo
+
+POM_DEVELOPER_ID=devs
+POM_DEVELOPER_NAME=Braintree Payments
+POM_DEVELOPER_EMAIL=sdks@paypal.com

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -1,0 +1,58 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+
+ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
+ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD') ?: ''
+ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId group
+                version project.version
+                artifactId project.ext.name
+                from components.release
+                artifact sourcesJar
+                artifact javadocsJar
+
+                pom {
+                    name = project.ext.pom_name ?: ''
+                    packaging = POM_PACKAGING
+                    description = project.ext.pom_desc ?: ''
+                    url = POM_URL
+                    licenses {
+                        license {
+                            name = POM_LICENSE_NAME
+                            url = POM_LICENSE_URL
+                            distribution = POM_LICENSE_DISTRIBUTION
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
+                            email = POM_DEVELOPER_EMAIL
+                        }
+                    }
+                    scm {
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                        url = POM_SCM_URL
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications
+        sign configurations.archives
+    }
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocsJar
+}

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -10,7 +10,7 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                groupId group
+                groupId project.ext.group_name
                 version project.version
                 artifactId project.ext.name
                 from components.release

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -10,7 +10,7 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                groupId project.ext.group_name
+                groupId group
                 version project.version
                 artifactId project.ext.name
                 from components.release

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -14,7 +14,7 @@ afterEvaluate {
                 version project.version
                 artifactId project.ext.name
                 from components.release
-                artifact sourcesJar
+                artifact androidSourcesJar
                 artifact javadocsJar
 
                 pom {
@@ -63,12 +63,13 @@ task javadocsJar(type: Jar, dependsOn: javadocs) {
     from javadocs.destinationDir
 }
 
-task sourcesJar(type: Jar) {
+task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     from android.sourceSets.main.java.srcDirs
+    from android.sourceSets.main.kotlin.srcDirs
 }
 
 artifacts {
-    archives sourcesJar
+    archives androidSourcesJar
     archives javadocsJar
 }

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -52,6 +52,22 @@ afterEvaluate {
     }
 }
 
+task javadocs(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
+}
+
+task javadocsJar(type: Jar, dependsOn: javadocs) {
+    archiveClassifier.set('javadoc')
+    from javadocs.destinationDir
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
 artifacts {
     archives sourcesJar
     archives javadocsJar

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -10,7 +10,7 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                groupId group
+                groupId project.ext.group_id
                 version project.version
                 artifactId project.ext.name
                 from components.release

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -11,7 +11,7 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 groupId project.ext.group_id
-                version project.version
+                version project.ext.version
                 artifactId project.ext.name
                 from components.release
                 artifact androidSourcesJar


### PR DESCRIPTION
Thank you for your contribution to Braintree. 


### Summary of changes

- Update to use [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin/wiki/Migration-from-gradle_nexus_staging-plugin---nexus_publish-plugin-duo) which is the replacement for the no longer maintained [Nexus Publish Plugin](https://github.com/marcphilipp/nexus-publish-plugin).
- This change has been tested through the publish staging repository step. The close and release repository step can't be tested until we are ready to release a new version of the SDK.

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
