### PR TITLE
Throw BrowserSwitchException When Unable to Start Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Throw `BrowserSwitchException` when a browser is not found to start browser switch
+
 ## 2.6.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 34

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -67,7 +68,11 @@ public class BrowserSwitchClient {
             customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
         } else {
             Intent launchUrlInBrowser = new Intent(Intent.ACTION_VIEW, browserSwitchUrl);
-            activity.startActivity(launchUrlInBrowser);
+            try {
+                activity.startActivity(launchUrlInBrowser);
+            } catch (ActivityNotFoundException e) {
+                throw new BrowserSwitchException("A web browser is required.");
+            }
         }
     }
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -71,7 +71,7 @@ public class BrowserSwitchClient {
             try {
                 activity.startActivity(launchUrlInBrowser);
             } catch (ActivityNotFoundException e) {
-                throw new BrowserSwitchException("A web browser is required.");
+                throw new BrowserSwitchException("Unable to start browser switch without a web browser.");
             }
         }
     }


### PR DESCRIPTION
### Summary of changes

 - Catch the `ActivityNotFoundException` that is thrown in `BrowserSwitchClient#start` when a browser app is not available, and throw a `BrowserSwitchException` as defined by the method contract
 - Will be used to resolve [issue in core SDK](https://github.com/braintree/braintree_android/issues/799)

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
