### PR TITLE
Add Integration Pattern without Local Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Breaking Changes
   * Change `BrowserSwitchClient#start` parameters and return type
   * Change `BrowserSwitchClient#parseResult` parameters 
-  * Add `BrowserSwitchRequest`
+  * Add `BrowserSwitchRequest` and `BrowserSwitchPendingRequest`
 
 ## 2.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Breaking Changes
+  * Change `BrowserSwitchClient#start` parameters and return type
+  * Change `BrowserSwitchClient#parseResult` parameters 
+
 ## 2.6.1
 
 * Throw `BrowserSwitchException` when a browser is not found to start browser switch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Breaking Changes
   * Change `BrowserSwitchClient#start` parameters and return type
   * Change `BrowserSwitchClient#parseResult` parameters 
+  * Add `BrowserSwitchRequest`
 
 ## 2.6.1
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 /**
  * Client that manages the logic for browser switching.
  */
+// NEXT_MAJOR_VERSION remove all methods except start with ComponentActivity and parseResult with BrowserSwitchRequest
 public class BrowserSwitchClient {
 
     private final BrowserSwitchInspector browserSwitchInspector;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -84,10 +84,9 @@ public class BrowserSwitchClient {
      *
      * @param activity the activity used to start browser switch
      * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
-     * @return a pending {@link BrowserSwitchRequest} that should be stored and passed to
-     * {@link BrowserSwitchClient#parseResult(BrowserSwitchRequest, Intent)} upon return to the app.
-     * Returns null if an exception is thrown.
-     * @throws BrowserSwitchException when a browser is unable to be launched for browser switching
+     * @return a {@link BrowserSwitchPendingRequest.Started} that should be stored and passed to
+     * {@link BrowserSwitchClient#parseResult(BrowserSwitchRequest, Intent)} upon return to the app,
+     * or {@link BrowserSwitchPendingRequest.Failure} if browser could not be launched.
      */
     @Nullable
     public BrowserSwitchPendingRequest start(@NonNull ComponentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) {
@@ -247,7 +246,7 @@ public class BrowserSwitchClient {
 
     /**
      * Parses and returns a browser switch result if a match is found for the given {@link BrowserSwitchRequest}
-     * @param request the pending {@link BrowserSwitchRequest} returned from
+     * @param pendingRequest the {@link BrowserSwitchPendingRequest.Started} returned from
      * {@link BrowserSwitchClient#start(ComponentActivity, BrowserSwitchOptions)}
      * @param intent the intent to return to your application containing a deep link result from the
      *               browser flow
@@ -255,12 +254,12 @@ public class BrowserSwitchClient {
      * null if the user returned to the app without completing the browser switch
      */
     @Nullable
-    public BrowserSwitchResult parseResult(@NonNull BrowserSwitchRequest request, @Nullable Intent intent) {
+    public BrowserSwitchResult parseResult(@NonNull BrowserSwitchPendingRequest.Started pendingRequest, @Nullable Intent intent) {
         BrowserSwitchResult result = null;
         if (intent != null && intent.getData() != null) {
             Uri deepLinkUrl = intent.getData();
-            if (request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
-                result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);
+            if (pendingRequest.getBrowserSwitchRequest().matchesDeepLinkUrlScheme(deepLinkUrl)) {
+                result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, pendingRequest.getBrowserSwitchRequest(), deepLinkUrl);
             }
         }
         return result;

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -77,6 +77,17 @@ public class BrowserSwitchClient {
         }
     }
 
+    /**
+     * Open a browser or <a href="https://developer.chrome.com/multidevice/android/customtabs">Chrome Custom Tab</a>
+     * with a given set of {@link BrowserSwitchOptions} from an Android activity.
+     *
+     * @param activity the activity used to start browser switch
+     * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
+     * @return a pending {@link BrowserSwitchRequest} that should be stored and passed to
+     * {@link BrowserSwitchClient#parseResult(BrowserSwitchRequest, Intent)} upon return to the app.
+     * Returns null if an exception is thrown.
+     * @throws BrowserSwitchException when a browser is unable to be launched for browser switching
+     */
     @Nullable
     public BrowserSwitchRequest start(@NonNull ComponentActivity activity, @NonNull BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {
         assertCanPerformBrowserSwitch(activity, browserSwitchOptions);
@@ -225,10 +236,19 @@ public class BrowserSwitchClient {
         return result;
     }
 
+    /**
+     * Parses and returns a browser switch result if a match is found for the given {@link BrowserSwitchRequest}
+     * @param request the pending {@link BrowserSwitchRequest} returned from
+     * {@link BrowserSwitchClient#start(ComponentActivity, BrowserSwitchOptions)}
+     * @param intent the intent to return to your application containing a deep link result from the
+     *               browser flow
+     * @return a {@link BrowserSwitchResult} if the browser switch was successfully completed, or
+     * null if the user returned to the app without completing the browser switch
+     */
     @Nullable
     public BrowserSwitchResult parseResult(@NonNull BrowserSwitchRequest request, @Nullable Intent intent) {
         BrowserSwitchResult result = null;
-        if (intent != null && intent.getData() != null && request != null) {
+        if (intent != null && intent.getData() != null) {
             Uri deepLinkUrl = intent.getData();
             if (request.matchesDeepLinkUrlScheme(deepLinkUrl)) {
                 result = new BrowserSwitchResult(BrowserSwitchStatus.SUCCESS, request, deepLinkUrl);

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -97,19 +97,23 @@ public class BrowserSwitchClient {
         String returnUrlScheme = browserSwitchOptions.getReturnUrlScheme();
 
         JSONObject metadata = browserSwitchOptions.getMetadata();
-        BrowserSwitchRequest request;
 
+        BrowserSwitchRequest request;
         if (activity.isFinishing()) {
             String activityFinishingMessage =
                     "Unable to start browser switch while host Activity is finishing.";
             throw new BrowserSwitchException(activityFinishingMessage);
         } else  {
             boolean launchAsNewTask = browserSwitchOptions.isLaunchAsNewTask();
-            request =
-                    new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme, true);
-            customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
+            try {
+                 request =
+                        new BrowserSwitchRequest(requestCode, browserSwitchUrl, metadata, returnUrlScheme, true);
+                customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
+            } catch (ActivityNotFoundException e) {
+                throw new BrowserSwitchException("Unable to start browser switch without a web browser.");
+            }
+            return request;
         }
-        return request;
     }
 
     void assertCanPerformBrowserSwitch(ComponentActivity activity, BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -13,7 +13,7 @@ sealed class BrowserSwitchPendingRequest {
     class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest()
 
     /**
-     * An [error] occurred launching the browser
+     * An error with [cause] occurred launching the browser
      */
-    class Failure(val error: Exception) : BrowserSwitchPendingRequest()
+    class Failure(val cause: Exception) : BrowserSwitchPendingRequest()
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -1,0 +1,8 @@
+package com.braintreepayments.api
+
+sealed class BrowserSwitchPendingRequest {
+
+    class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest()
+
+    class Failure(val error: Exception) : BrowserSwitchPendingRequest()
+}

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -1,8 +1,19 @@
 package com.braintreepayments.api
 
+/**
+ * A pending request for browser switching. This pending request should be stored locally within the app or
+ * on-device and used to deliver a result of the browser flow in [BrowserSwitchClient.parseResult]
+ */
 sealed class BrowserSwitchPendingRequest {
 
+    /**
+     * A browser switch was successfully started. This pending request should be store dnd passed to
+     * [BrowserSwitchClient.parseResult]
+    */
     class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest()
 
+    /**
+     * An [error] occurred launching the browser
+     */
     class Failure(val error: Exception) : BrowserSwitchPendingRequest()
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-class BrowserSwitchRequest {
+public class BrowserSwitchRequest {
 
 
     private final Uri url;

--- a/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
@@ -1,5 +1,6 @@
 package com.braintreepayments.api;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -20,7 +21,7 @@ class ChromeCustomTabsInternalClient {
         this.customTabsIntentBuilder = builder;
     }
 
-    void launchUrl(Context context, Uri url, boolean launchAsNewTask) {
+    void launchUrl(Context context, Uri url, boolean launchAsNewTask) throws ActivityNotFoundException{
         CustomTabsIntent customTabsIntent = customTabsIntentBuilder.build();
         if (launchAsNewTask) {
             customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -384,17 +384,16 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void parseResult_whenActiveRequestMatchesRequestCodeAndDeepLinkResultURLScheme_returnsBrowserSwitchSuccessResult() {
+    public void parseResult_whenActiveRequestMatchesDeepLinkResultURLScheme_returnsBrowserSwitchSuccessResult() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
             new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
-        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
 
         Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
         Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), intent);
 
         assertNotNull(browserSwitchResult);
         assertEquals(BrowserSwitchStatus.SUCCESS, browserSwitchResult.getStatus());
@@ -402,45 +401,16 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void parseResult_whenActiveRequestMatchesRequestCodeAndDeepLinkResultURLSchemeDoesntMatch_returnsNull() {
+    public void parseResult_whenDeepLinkResultURLSchemeDoesntMatch_returnsNull() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
 
         JSONObject requestMetadata = new JSONObject();
         BrowserSwitchRequest request =
                 new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
-        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
 
         Uri deepLinkUrl = Uri.parse("a-different-url-scheme://success");
         Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
-
-        assertNull(browserSwitchResult);
-    }
-
-    @Test
-    public void parseResult_whenActiveRequestDoesntMatchRequestCode_returnsNull() {
-        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
-
-        JSONObject requestMetadata = new JSONObject();
-        BrowserSwitchRequest request =
-                new BrowserSwitchRequest(456, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
-        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(request);
-
-        Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
-        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
-
-        assertNull(browserSwitchResult);
-    }
-
-    @Test
-    public void parseResult_whenNoActiveRequestExists_returnsNull() {
-        BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
-        when(persistentStore.getActiveRequest(same(applicationContext))).thenReturn(null);
-
-        Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
-        Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, intent);
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), intent);
 
         assertNull(browserSwitchResult);
     }
@@ -449,7 +419,11 @@ public class BrowserSwitchClientUnitTest {
     public void parseResult_whenIntentIsNull_returnsNull() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector, persistentStore, customTabsInternalClient);
 
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(applicationContext, 123, null);
+        JSONObject requestMetadata = new JSONObject();
+        BrowserSwitchRequest request =
+                new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
+
+        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), null);
         assertNull(browserSwitchResult);
     }
 

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -90,7 +90,7 @@ public class BrowserSwitchClientUnitTest {
 
         BrowserSwitchPendingRequest request = sut.start(componentActivity, options);
         assertTrue(request instanceof BrowserSwitchPendingRequest.Failure);
-        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getError().getMessage(), "Unable to start browser switch while host Activity is finishing.");
+        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getCause().getMessage(), "Unable to start browser switch while host Activity is finishing.");
     }
 
     @Test
@@ -134,7 +134,7 @@ public class BrowserSwitchClientUnitTest {
                 .metadata(metadata);
         BrowserSwitchPendingRequest request = sut.start(componentActivity, options);
         assertTrue(request instanceof BrowserSwitchPendingRequest.Failure);
-        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getError().getMessage(), "Unable to start browser switch without a web browser.");
+        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getCause().getMessage(), "Unable to start browser switch without a web browser.");
     }
     @Test
     public void start_whenRequestCodeIsIntegerMinValue_returnsFailure() {
@@ -150,7 +150,7 @@ public class BrowserSwitchClientUnitTest {
                 .metadata(metadata);
         BrowserSwitchPendingRequest request = sut.start(componentActivity, options);
         assertTrue(request instanceof BrowserSwitchPendingRequest.Failure);
-        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getError().getMessage(), "Request code cannot be Integer.MIN_VALUE");
+        assertEquals(((BrowserSwitchPendingRequest.Failure) request).getCause().getMessage(), "Request code cannot be Integer.MIN_VALUE");
     }
 
     @Test
@@ -171,7 +171,7 @@ public class BrowserSwitchClientUnitTest {
         assertEquals("The return url scheme was not set up, incorrectly set up, or more than one " +
                 "Activity on this device defines the same url scheme in it's Android Manifest. " +
                 "See https://github.com/braintree/browser-switch-android for more information on " +
-                "setting up a return url scheme.", ((BrowserSwitchPendingRequest.Failure) request).getError().getMessage());
+                "setting up a return url scheme.", ((BrowserSwitchPendingRequest.Failure) request).getCause().getMessage());
     }
 
     @Test
@@ -188,7 +188,7 @@ public class BrowserSwitchClientUnitTest {
                 .metadata(metadata);
         BrowserSwitchPendingRequest request = sut.start(componentActivity, options);
         assertTrue(request instanceof BrowserSwitchPendingRequest.Failure);
-        assertEquals("A returnUrlScheme is required.", ((BrowserSwitchPendingRequest.Failure) request).getError().getMessage());
+        assertEquals("A returnUrlScheme is required.", ((BrowserSwitchPendingRequest.Failure) request).getCause().getMessage());
     }
 
     @Test

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -15,7 +15,7 @@ afterEvaluate {
                 artifactId project.ext.name
                 from components.release
                 artifact androidSourcesJar
-                artifact javadocsJar
+//                artifact javadocsJar
 
                 pom {
                     name = project.ext.pom_name ?: ''
@@ -46,10 +46,10 @@ afterEvaluate {
         }
     }
 
-    signing {
-        sign publishing.publications
-        sign configurations.archives
-    }
+//    signing {
+//        sign publishing.publications
+//        sign configurations.archives
+//    }
 }
 
 task javadocs(type: Javadoc) {

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -15,7 +15,7 @@ afterEvaluate {
                 artifactId project.ext.name
                 from components.release
                 artifact androidSourcesJar
-//                artifact javadocsJar
+                artifact javadocsJar
 
                 pom {
                     name = project.ext.pom_name ?: ''
@@ -46,10 +46,10 @@ afterEvaluate {
         }
     }
 
-//    signing {
-//        sign publishing.publications
-//        sign configurations.archives
-//    }
+    signing {
+        sign publishing.publications
+        sign configurations.archives
+    }
 }
 
 task javadocs(type: Javadoc) {


### PR DESCRIPTION
### Summary of changes

 - Add `BrowserSwitchClient.start` method that returns a `BrowserSwitchRequest` to allow integrators to store the pending request locally and pass it to new `BrowserSwithClient.parseResult` method to deliver browser switch results.
 - Remove storing pending requests in shared preferences in favor of allowing integrators to store the pending requests within their own app in whatever way works best for their architecture - this allows integrators to check if they have an existing pending request (i.e. they've launched a browser switch), before trying to fetch a result. The effect is that if they have a pending request, but don't receive a result, they can infer that the browser switch was cancelled or not completed and can handle accordingly. 
 - See this [draft PR](https://github.com/braintree/braintree_android/pull/883) for how this integration will look in the PayPal flow of the Braintree SDK
 - Future PRs will remove all other now unnecessary methods of BraintreeClient, and update the demo app

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
