### PR TITLE
Add Convenience String Methods to BrowserSwitchPendingRequest

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -1,5 +1,7 @@
 package com.braintreepayments.api
 
+import org.json.JSONException
+
 /**
  * A pending request for browser switching. This pending request should be stored locally within the app or
  * on-device and used to deliver a result of the browser flow in [BrowserSwitchClient.parseResult]
@@ -14,9 +16,13 @@ sealed class BrowserSwitchPendingRequest {
 
         /**
          * Convenience constructor to create a [BrowserSwitchPendingRequest.Started] from your stored
-         * [String] from [BrowserSwitchPendingRequest.Started.toJsonString]
+         * [String] from [BrowserSwitchPendingRequest.Started.toJsonString].
+         * @throws [JSONException] if the [jsonString] is invalid.
          */
-        constructor(jsonString: String) : this(BrowserSwitchRequest.fromJson(jsonString))
+        @Throws(JSONException::class)
+        constructor(jsonString: String) : this(
+            BrowserSwitchRequest.fromJson(jsonString)
+        )
 
         /**
          * Convenience method to return [BrowserSwitchPendingRequest.Started] in [String] format to be

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -10,7 +10,22 @@ sealed class BrowserSwitchPendingRequest {
      * A browser switch was successfully started. This pending request should be store dnd passed to
      * [BrowserSwitchClient.parseResult]
     */
-    class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest()
+    class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest() {
+
+        /**
+         * Convenience constructor to create a [BrowserSwitchPendingRequest.Started] from your stored
+         * [String] from [BrowserSwitchPendingRequest.Started.toJsonString]
+         */
+        constructor(jsonString: String) : this(BrowserSwitchRequest.fromJson(jsonString))
+
+        /**
+         * Convenience method to return [BrowserSwitchPendingRequest.Started] in [String] format to be
+         * persisted in storage
+         */
+        fun toJsonString(): String {
+            return browserSwitchRequest.toJson()
+        }
+    }
 
     /**
      * An error with [cause] occurred launching the browser

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -3,6 +3,7 @@ package com.braintreepayments.api;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,7 +14,8 @@ public class BrowserSwitchRequest {
     private final Uri url;
     private final int requestCode;
     private final JSONObject metadata;
-    private final String returnUrlScheme;
+    @VisibleForTesting
+    final String returnUrlScheme;
     private boolean shouldNotifyCancellation;
 
     static BrowserSwitchRequest fromJson(String json) throws JSONException {

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
@@ -20,7 +20,6 @@ class BrowserSwitchPendingRequestUnitTest {
 
     @Test
     fun startedConstructor_fromString_createsBrowserSwitchRequest() {
-
         val pendingRequest = BrowserSwitchPendingRequest.Started(browserSwitchRequest)
         val storedRequest = pendingRequest.toJsonString()
 

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
@@ -1,6 +1,7 @@
 package com.braintreepayments.api
 
 import android.net.Uri
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -35,6 +36,11 @@ class BrowserSwitchPendingRequestUnitTest {
             sut.browserSwitchRequest.shouldNotifyCancellation
         )
         assertEquals(browserSwitchRequest.returnUrlScheme, sut.browserSwitchRequest.returnUrlScheme)
+    }
+
+    @Test(expected = JSONException::class)
+    fun startedConstructor_fromString_whenInvalidString_throwsJSONException() {
+        val sut = BrowserSwitchPendingRequest.Started("{}")
     }
 
     @Test

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
@@ -1,0 +1,6 @@
+package com.braintreepayments.api
+
+class BrowserSwitchPendingRequestUnitTest {
+
+    
+}

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchPendingRequestUnitTest.kt
@@ -1,6 +1,48 @@
 package com.braintreepayments.api
 
+import android.net.Uri
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
 class BrowserSwitchPendingRequestUnitTest {
 
-    
+    private val browserSwitchRequest = BrowserSwitchRequest(
+        1,
+        Uri.parse("http://"),
+        JSONObject().put("test_key", "test_value"),
+        "return-url-scheme",
+        false
+    )
+
+    @Test
+    fun startedConstructor_fromString_createsBrowserSwitchRequest() {
+
+        val pendingRequest = BrowserSwitchPendingRequest.Started(browserSwitchRequest)
+        val storedRequest = pendingRequest.toJsonString()
+
+        val sut = BrowserSwitchPendingRequest.Started(storedRequest)
+        assertEquals(browserSwitchRequest.requestCode, sut.browserSwitchRequest.requestCode)
+        assertEquals(
+            browserSwitchRequest.metadata.getString("test_key"),
+            sut.browserSwitchRequest.metadata.getString("test_key")
+        )
+        assertEquals(browserSwitchRequest.url, sut.browserSwitchRequest.url)
+        assertEquals(
+            browserSwitchRequest.shouldNotifyCancellation,
+            sut.browserSwitchRequest.shouldNotifyCancellation
+        )
+        assertEquals(browserSwitchRequest.returnUrlScheme, sut.browserSwitchRequest.returnUrlScheme)
+    }
+
+    @Test
+    fun toJsonString_returnsJsonBrowserSwitchRequest() {
+        val sut = BrowserSwitchPendingRequest.Started(browserSwitchRequest)
+        val jsonString = sut.toJsonString()
+
+        assertEquals(browserSwitchRequest.toJson(), jsonString)
+    }
 }


### PR DESCRIPTION
### Summary of changes

 - Add `fromString` and `toJsonString` convenience methods to `BrowserSwitchPendingRequest`. This allows merchants to store the pending request in any data store that allows string data

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
