### PR TITLE
Upgrade Gradle Dependencies

### DIFF
--- a/.github/actions/setup_java/action.yml
+++ b/.github/actions/setup_java/action.yml
@@ -6,5 +6,5 @@ runs:
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: zulu

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'microsoft'
       - name: Lint
         run: ./ci android_lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
       - name: Unit Tests
         run: ./ci unit_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## unreleased
 
 * Breaking Changes
+  * Bump `minSdkVersion` to API 23
+  * Bump target Java version to Java 11
+  * Upgrade Kotlin version to 1.9.10
+  * Upgrade to Android Gradle Plugin 8
   * Change `BrowserSwitchClient#start` parameters and return type
   * Change `BrowserSwitchClient#parseResult` parameters 
   * Remove `deliverResult`, `getResult`, `captureResult`, `clearActiveRequests`, `getResultFromCache`, and `deliverResultFromCache` from `BrowserSwitchClient`

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    namespace "com.braintreepayments.api.browserswitch"
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -15,8 +16,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility versions.javaSourceCompatibility
+        targetCompatibility versions.javaTargetCompatibility
+    }
+    kotlinOptions {
+        jvmTarget = "11"
     }
 
     // robolectric

--- a/browser-switch/src/main/AndroidManifest.xml
+++ b/browser-switch/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.braintreepayments.api.browserswitch">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <queries>
         <intent>

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
 
     def sdkTargetJavaVersion = JavaVersion.VERSION_11
     ext.versions = [
-            "javaSourceCompatibility": sdkTargetJavaVersion,
-            "javaTargetCompatibility": sdkTargetJavaVersion,
+        "javaSourceCompatibility": sdkTargetJavaVersion,
+        "javaTargetCompatibility": sdkTargetJavaVersion,
     ]
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,14 @@ buildscript {
         }
     }
 
+    def sdkTargetJavaVersion = JavaVersion.VERSION_11
+    ext.versions = [
+            "kotlin"         : "1.7.10",
+            "javaSourceCompatibility": sdkTargetJavaVersion,
+            "javaTargetCompatibility": sdkTargetJavaVersion,
+    ]
+
+
     ext.deps = [
         'annotation'  : 'androidx.annotation:annotation:1.7.0',
         'appcompat'   : 'androidx.appcompat:appcompat:1.6.0',
@@ -21,7 +29,7 @@ buildscript {
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.20'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     ext.deps = [
-        'annotation'  : 'androidx.annotation:annotation:1.2.0',
-        'appcompat'   : 'androidx.appcompat:appcompat:1.3.1',
-        'browser'     : 'androidx.browser:browser:1.5.0',
+        'annotation'  : 'androidx.annotation:annotation:1.7.0',
+        'appcompat'   : 'androidx.appcompat:appcompat:1.6.0',
+        'browser'     : 'androidx.browser:browser:1.7.0',
         'kotlin'      : 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10',
 
         // test dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ version = '3.0.0-beta1-SNAPSHOT'
 group = "com.braintreepayments"
 ext {
     compileSdkVersion = 34
-    minSdkVersion = 21
+    minSdkVersion = 23
     targetSdkVersion = 34
     versionCode = 69
     versionName = version

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 
     def sdkTargetJavaVersion = JavaVersion.VERSION_11
     ext.versions = [
-            "kotlin"         : "1.7.10",
             "javaSourceCompatibility": sdkTargetJavaVersion,
             "javaTargetCompatibility": sdkTargetJavaVersion,
     ]
@@ -19,25 +18,25 @@ buildscript {
         'annotation'  : 'androidx.annotation:annotation:1.7.0',
         'appcompat'   : 'androidx.appcompat:appcompat:1.6.0',
         'browser'     : 'androidx.browser:browser:1.7.0',
-        'kotlin'      : 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10',
+        'kotlin'      : 'org.jetbrains.kotlin:kotlin-stdlib:1.9.20',
 
         // test dependencies
         'junit'       : 'junit:junit:4.13.2',
-        'mockitoCore' : 'org.mockito:mockito-core:3.4.0',
+        'mockitoCore' : 'org.mockito:mockito-core:5.7.0',
         'jsonassert'  : 'org.skyscreamer:jsonassert:1.5.1',
-        'robolectric' : 'org.robolectric:robolectric:4.7.3'
+        'robolectric' : 'org.robolectric:robolectric:4.11.1'
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.20'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
+        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.9.10'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
     }
 }
 
 plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
-    id 'org.jetbrains.dokka' version '1.7.10'
+    id 'org.jetbrains.dokka' version '1.9.10'
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    namespace "com.braintreepayments.api.demo"
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
         applicationId "com.braintreepayments.api.browserswitch.demo"
@@ -17,11 +18,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility versions.javaSourceCompatibility
+        targetCompatibility versions.javaTargetCompatibility
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "11"
     }
     buildFeatures {
         compose true
@@ -38,9 +39,9 @@ android {
 
 dependencies {
     implementation project(':browser-switch')
-    implementation "androidx.annotation:annotation:1.3.0"
-    implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation "androidx.fragment:fragment:1.3.6"
+    implementation "androidx.annotation:annotation:1.7.1"
+    implementation "androidx.appcompat:appcompat:1.6.1"
+    implementation "androidx.fragment:fragment-ktx:1.6.2"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation platform('androidx.compose:compose-bom:2023.03.00')

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.braintreepayments.api.demo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="false"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 
 # Ref: https://stackoverflow.com/a/50673210
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 POM_PACKAGING=aar
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ POM_LICENSE_DISTRIBUTION=repo
 POM_DEVELOPER_ID=devs
 POM_DEVELOPER_NAME=Braintree Payments
 POM_DEVELOPER_EMAIL=sdks@paypal.com
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jul 17 09:55:05 CDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary of changes

 - Upgrade gradle dependencies to latest (and align with BT Core SDK versions)
 - Bump Java version to 11 and Kotlin to 1.9.10
 - Upgrade to Android Gradle Plugin 8 (aligns with core)
 - Bump min SDK version to 23 - there isn't anything specific in this SDK that requires the min version bump, but this gives us more flexibility and aligns with the Core v5 min SDK version

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
