### PR TITLE
Fix Javadocs Task for SNAPSHOT Publish

### DIFF
--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -54,8 +54,7 @@ afterEvaluate {
 }
 
 task javadocs(type: Javadoc) {
-    source = project.android.sourceSets.main.java.srcDirs
-//    classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
+    source = android.sourceSets.main.java.srcDirs
     failOnError false
 }
 

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -6,7 +6,6 @@ ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
 ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD') ?: ''
 ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
 
-
 afterEvaluate {
     publishing {
         publications {

--- a/gradle/gradle-publish.gradle
+++ b/gradle/gradle-publish.gradle
@@ -6,6 +6,7 @@ ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID') ?: ''
 ext["signing.password"] = System.getenv('SIGNING_KEY_PASSWORD') ?: ''
 ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_KEY_FILE') ?: ''
 
+
 afterEvaluate {
     publishing {
         publications {
@@ -53,8 +54,8 @@ afterEvaluate {
 }
 
 task javadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    source = project.android.sourceSets.main.java.srcDirs
+//    classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
     failOnError false
 }
 


### PR DESCRIPTION
### Summary of changes

 - Fix javadocs task breaking SNAPSHOT publishing when using AGP 8

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 
