### PR TITLE
Update assertCanPerformBrowserSwitch to accommodate app links

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -77,7 +77,10 @@ public class BrowserSwitchClient {
         }
     }
 
-    void assertCanPerformBrowserSwitch(FragmentActivity activity, BrowserSwitchOptions browserSwitchOptions) throws BrowserSwitchException {
+    void assertCanPerformBrowserSwitch(
+        FragmentActivity activity,
+        BrowserSwitchOptions browserSwitchOptions
+    ) throws BrowserSwitchException {
         Context appContext = activity.getApplicationContext();
 
         int requestCode = browserSwitchOptions.getRequestCode();
@@ -87,9 +90,10 @@ public class BrowserSwitchClient {
 
         if (!isValidRequestCode(requestCode)) {
             errorMessage = activity.getString(R.string.error_request_code_invalid);
-        } else if (returnUrlScheme == null) {
-            errorMessage = activity.getString(R.string.error_return_url_required);
-        } else if (!browserSwitchInspector.isDeviceConfiguredForDeepLinking(appContext, returnUrlScheme)) {
+        } else if (returnUrlScheme == null && browserSwitchOptions.getAppLinkUri() == null) {
+            errorMessage = activity.getString(R.string.error_app_link_uri_or_return_url_required);
+        } else if (returnUrlScheme != null &&
+            !browserSwitchInspector.isDeviceConfiguredForDeepLinking(appContext, returnUrlScheme)) {
             errorMessage = activity.getString(R.string.error_device_not_configured_for_deep_link);
         }
 

--- a/browser-switch/src/main/res/values/strings.xml
+++ b/browser-switch/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="error_request_code_invalid">Request code cannot be Integer.MIN_VALUE</string>
-    <string name="error_return_url_required">A returnUrlScheme is required.</string>
+    <string name="error_app_link_uri_or_return_url_required">An appLinkUri or returnUrlScheme is required.</string>
     <string name="error_browser_not_found">No installed activities can open this URL: %1$s</string>
     <string name="error_device_not_configured_for_deep_link">The return url scheme was not set up, incorrectly set up, or more than one Activity on this device defines the same url scheme in it\'s Android Manifest. See https://github.com/braintree/browser-switch-android for more information on setting up a return url scheme.</string>
 </resources>

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -228,7 +228,7 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void start_whenNoReturnUrlSchemeSet_throwsError() {
+    public void start_whenNoAppLinkUriOrReturnUrlSchemeSet_throwsError() {
         when(browserSwitchInspector.deviceHasBrowser(applicationContext)).thenReturn(true);
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
 
@@ -238,13 +238,14 @@ public class BrowserSwitchClientUnitTest {
         BrowserSwitchOptions options = new BrowserSwitchOptions()
                 .requestCode(123)
                 .returnUrlScheme(null)
+                .appLinkUri(null)
                 .url(browserSwitchDestinationUrl)
                 .metadata(metadata);
         try {
             sut.start(activity, options);
             fail("should fail");
         } catch (BrowserSwitchException e) {
-            assertEquals("A returnUrlScheme is required.", e.getMessage());
+            assertEquals("An appLinkUri or returnUrlScheme is required.", e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Summary of changes

 - Update `assertCanPerformBrowserSwitch` in `BrowserSwitchClient` to accommodate `BrowserSwitchOptions.appLinkUri`

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
