### PR TITLE
Demo App - Add App Link toggle to DemoFragment

### DIFF
--- a/demo/src/main/res/layout/demo_fragment.xml
+++ b/demo/src/main/res/layout/demo_fragment.xml
@@ -8,6 +8,17 @@
     tools:context=".DemoFragment"
     >
 
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/navigation_link_type"/>
+
+    <Spinner
+        android:id="@+id/link_spinner"
+        android:layout_width="match_parent"
+        android:layout_marginBottom="12dp"
+        android:layout_height="wrap_content" />
+
     <Button
         android:id="@+id/browser_switch"
         android:layout_width="match_parent"

--- a/demo/src/main/res/values/arrays.xml
+++ b/demo/src/main/res/values/arrays.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string-array name="navigation_links">
+        <item name="deep_link">Deep Link</item>
+        <item name="app_link">App Link</item>
+    </string-array>
+
+</resources>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="browser_switch_btn_text">Start Browser Switch</string>
     <string name="browser_switch_with_metadata_btn_text">Start Browser Switch With Metadata</string>
+    <string name="navigation_link_type">Navigation Link Type:</string>
 </resources>


### PR DESCRIPTION
### Summary of changes

 - Add deep link / app link toggle to `DemoFragment`
 - Configure app link flow using `https://mobile-sdk-demo-site-838cead5d3ab.herokuapp.com` url

![Screenshot_20240508_161515](https://github.com/braintree/browser-switch-android/assets/5005216/de7c2651-8333-4787-a565-d8bcf3a45499)

Related popup bridge PR: https://github.com/braintree/popup-bridge-example/pull/10

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
