### PR TITLE
Handle when BrowserSwitchResult has a null returnUrlScheme and update matchesAppLinkUri logic

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchRequest.java
@@ -22,11 +22,14 @@ class BrowserSwitchRequest {
         JSONObject jsonObject = new JSONObject(json);
         int requestCode = jsonObject.getInt("requestCode");
         String url = jsonObject.getString("url");
-        String returnUrlScheme = jsonObject.getString("returnUrlScheme");
         JSONObject metadata = jsonObject.optJSONObject("metadata");
         Uri appLinkUri = null;
         if (jsonObject.has("appLinkUri")) {
             appLinkUri = Uri.parse(jsonObject.getString("appLinkUri"));
+        }
+        String returnUrlScheme = null;
+        if (jsonObject.has("returnUrlScheme")) {
+            returnUrlScheme = jsonObject.getString("returnUrlScheme");
         }
         boolean shouldNotify = jsonObject.optBoolean("shouldNotify", true);
         return new BrowserSwitchRequest(
@@ -106,6 +109,8 @@ class BrowserSwitchRequest {
     }
 
     boolean matchesAppLinkUri(@NonNull Uri uri) {
-        return appLinkUri != null && uri.toString().equals(appLinkUri.toString());
+        return appLinkUri != null &&
+            uri.getScheme().equals(appLinkUri.getScheme()) &&
+            uri.getHost().equals(appLinkUri.getHost());
     }
 }

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchRequestUnitTest.java
@@ -119,6 +119,27 @@ public class BrowserSwitchRequestUnitTest {
     }
 
     @Test
+    public void toJson_for_appLinkUri_without_returnUrlScheme() throws JSONException {
+        String json = "{\n" +
+            "  \"requestCode\": 123,\n" +
+            "  \"url\": \"https://example.com\",\n" +
+            "  \"shouldNotify\": false,\n" +
+            "  \"appLinkUri\": \"https://example.com\",\n" +
+            "  \"metadata\": {\n" +
+            "    \"testKey\": \"testValue\"" +
+            "  }" +
+            "}";
+        BrowserSwitchRequest original = BrowserSwitchRequest.fromJson(json);
+        BrowserSwitchRequest restored = BrowserSwitchRequest.fromJson(original.toJson());
+
+        assertEquals(restored.getRequestCode(), original.getRequestCode());
+        assertEquals(restored.getUrl(), original.getUrl());
+        assertEquals("https://example.com", restored.getAppLinkUri().toString());
+        assertFalse(restored.getShouldNotifyCancellation());
+        JSONAssert.assertEquals(restored.getMetadata(), original.getMetadata(), true);
+    }
+
+    @Test
     public void matchesDeepLinkUrlScheme_whenSameSchemeDifferentCase_returnsTrue() throws JSONException {
         String json = "{\n" +
                 "  \"requestCode\": 123,\n" +
@@ -164,7 +185,39 @@ public class BrowserSwitchRequestUnitTest {
     }
 
     @Test
-    public void matchesAppLinkUri_whenDifferent_returnsFalse() throws JSONException {
+    public void matchesAppLinkUri_whenTheSame_withQueryParams_returnsTrue() throws JSONException {
+        String json = "{\n" +
+            "  \"requestCode\": 123,\n" +
+            "  \"url\": \"https://example.com\",\n" +
+            "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+            "  \"appLinkUri\": \"https://example.com\",\n" +
+            "  \"shouldNotify\": false,\n" +
+            "  \"metadata\": {\n" +
+            "    \"testKey\": \"testValue\"" +
+            "  }" +
+            "}";
+        BrowserSwitchRequest request = BrowserSwitchRequest.fromJson(json);
+        assertTrue(request.matchesAppLinkUri(Uri.parse("https://example.com?isAppLink=true")));
+    }
+
+    @Test
+    public void matchesAppLinkUri_whenSchemeIsDifferent_returnsFalse() throws JSONException {
+        String json = "{\n" +
+            "  \"requestCode\": 123,\n" +
+            "  \"url\": \"https://example.com\",\n" +
+            "  \"returnUrlScheme\": \"my-return-url-scheme\",\n" +
+            "  \"appLinkUri\": \"http://example.com\",\n" +
+            "  \"shouldNotify\": false,\n" +
+            "  \"metadata\": {\n" +
+            "    \"testKey\": \"testValue\"" +
+            "  }" +
+            "}";
+        BrowserSwitchRequest request = BrowserSwitchRequest.fromJson(json);
+        assertFalse(request.matchesAppLinkUri(Uri.parse("https://example.com")));
+    }
+
+    @Test
+    public void matchesAppLinkUri_whenHostIsDifferent_returnsFalse() throws JSONException {
         String json = "{\n" +
             "  \"requestCode\": 123,\n" +
             "  \"url\": \"https://example.com\",\n" +


### PR DESCRIPTION
### Summary of changes

 - Handle when `BrowserSwitchResult` has a null `returnUrlScheme` for the App Link flow
 - Update `matchesAppLinkUri` logic to only check for a matching host and scheme


https://github.com/braintree/browser-switch-android/assets/5005216/54645fba-acaf-4ed8-9305-e0b89e6733fd

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
