### PR TITLE
Rename parseResult to completeRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Add `BrowserSwitchRequest` and `BrowserSwitchPendingRequest`
   * Convert `BrowserSwitchResult` to sealed class and add `BrowserSwitchResultInfo`
   * Remove `BrowserSwitchStatus`
+  * Rename `parseResult()` to `completeRequest()`
 
 ## 2.6.1
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -44,7 +44,7 @@ public class BrowserSwitchClient {
      * @param activity the activity used to start browser switch
      * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
      * @return a {@link BrowserSwitchPendingRequest.Started} that should be stored and passed to
-     * {@link BrowserSwitchClient#parseResult(BrowserSwitchPendingRequest.Started, Intent)} upon return to the app,
+     * {@link BrowserSwitchClient#completeRequest(BrowserSwitchPendingRequest.Started, Intent)} upon return to the app,
      * or {@link BrowserSwitchPendingRequest.Failure} if browser could not be launched.
      */
     @NonNull
@@ -115,7 +115,8 @@ public class BrowserSwitchClient {
     }
 
     /**
-     * Parses and returns a browser switch result if a match is found for the given {@link BrowserSwitchRequest}
+     * Completes the browser switch flow and returns a browser switch result if a match is found for
+     * the given {@link BrowserSwitchRequest}
      * @param pendingRequest the {@link BrowserSwitchPendingRequest.Started} returned from
      * {@link BrowserSwitchClient#start(ComponentActivity, BrowserSwitchOptions)}
      * @param intent the intent to return to your application containing a deep link result from the
@@ -125,7 +126,7 @@ public class BrowserSwitchClient {
      * {@link BrowserSwitchPendingRequest.Started}. A {@link BrowserSwitchResult.NoResult} will be
      * returned if the user returns to the app without completing the browser switch flow.
      */
-    public BrowserSwitchResult parseResult(@NonNull BrowserSwitchPendingRequest.Started pendingRequest, @Nullable Intent intent) {
+    public BrowserSwitchResult completeRequest(@NonNull BrowserSwitchPendingRequest.Started pendingRequest, @Nullable Intent intent) {
         if (intent != null && intent.getData() != null) {
             Uri deepLinkUrl = intent.getData();
             if (pendingRequest.getBrowserSwitchRequest().matchesDeepLinkUrlScheme(deepLinkUrl)) {

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchPendingRequest.kt
@@ -4,13 +4,13 @@ import org.json.JSONException
 
 /**
  * A pending request for browser switching. This pending request should be stored locally within the app or
- * on-device and used to deliver a result of the browser flow in [BrowserSwitchClient.parseResult]
+ * on-device and used to deliver a result of the browser flow in [BrowserSwitchClient.completeRequest]
  */
 sealed class BrowserSwitchPendingRequest {
 
     /**
      * A browser switch was successfully started. This pending request should be store dnd passed to
-     * [BrowserSwitchClient.parseResult]
+     * [BrowserSwitchClient.completeRequest]
     */
     class Started(val browserSwitchRequest: BrowserSwitchRequest) : BrowserSwitchPendingRequest() {
 

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchResult.kt
@@ -1,7 +1,7 @@
 package com.braintreepayments.api
 
 /**
- * The result of a browser switch obtained from [BrowserSwitchClient.parseResult]
+ * The result of a browser switch obtained from [BrowserSwitchClient.completeRequest]
  */
 sealed class BrowserSwitchResult {
 

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -178,7 +178,7 @@ public class BrowserSwitchClientUnitTest {
     }
 
     @Test
-    public void parseResult_whenActiveRequestMatchesDeepLinkResultURLScheme_returnsBrowserSwitchSuccessResult() {
+    public void completeRequest_whenActiveRequestMatchesDeepLinkResultURLScheme_returnsBrowserSwitchSuccessResult() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector,
                 customTabsInternalClient);
 
@@ -188,14 +188,14 @@ public class BrowserSwitchClientUnitTest {
 
         Uri deepLinkUrl = Uri.parse("fake-url-scheme://success");
         Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), intent);
+        BrowserSwitchResult browserSwitchResult = sut.completeRequest(new BrowserSwitchPendingRequest.Started(request), intent);
 
         assertTrue(browserSwitchResult instanceof BrowserSwitchResult.Success);
         assertEquals(deepLinkUrl, ((BrowserSwitchResult.Success) browserSwitchResult).getResultInfo().getDeepLinkUrl());
     }
 
     @Test
-    public void parseResult_whenDeepLinkResultURLSchemeDoesntMatch_returnsNoResult() {
+    public void completeRequest_whenDeepLinkResultURLSchemeDoesntMatch_returnsNoResult() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector,
                 customTabsInternalClient);
 
@@ -205,13 +205,13 @@ public class BrowserSwitchClientUnitTest {
 
         Uri deepLinkUrl = Uri.parse("a-different-url-scheme://success");
         Intent intent = new Intent(Intent.ACTION_VIEW, deepLinkUrl);
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), intent);
+        BrowserSwitchResult browserSwitchResult = sut.completeRequest(new BrowserSwitchPendingRequest.Started(request), intent);
 
         assertTrue(browserSwitchResult instanceof BrowserSwitchResult.NoResult);
     }
 
     @Test
-    public void parseResult_whenIntentIsNull_returnsNoResult() {
+    public void completeRequest_whenIntentIsNull_returnsNoResult() {
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector,
                 customTabsInternalClient);
 
@@ -219,7 +219,7 @@ public class BrowserSwitchClientUnitTest {
         BrowserSwitchRequest request =
                 new BrowserSwitchRequest(123, browserSwitchDestinationUrl, requestMetadata, "fake-url-scheme", false);
 
-        BrowserSwitchResult browserSwitchResult = sut.parseResult(new BrowserSwitchPendingRequest.Started(request), null);
+        BrowserSwitchResult browserSwitchResult = sut.completeRequest(new BrowserSwitchPendingRequest.Started(request), null);
         assertTrue(browserSwitchResult instanceof BrowserSwitchResult.NoResult);
     }
 }

--- a/demo/src/main/java/com/braintreepayments/api/demo/ComposeActivity.kt
+++ b/demo/src/main/java/com/braintreepayments/api/demo/ComposeActivity.kt
@@ -50,7 +50,7 @@ class ComposeActivity : ComponentActivity() {
         super.onResume()
         PendingRequestStore.get(this)?.let { startedRequest ->
             when (val browserSwitchResult =
-                browserSwitchClient.parseResult(startedRequest, intent)) {
+                browserSwitchClient.completeRequest(startedRequest, intent)) {
                 is BrowserSwitchResult.Success -> viewModel.browserSwitchResult =
                     browserSwitchResult.resultInfo
 

--- a/demo/src/main/java/com/braintreepayments/api/demo/DemoActivitySingleTop.java
+++ b/demo/src/main/java/com/braintreepayments/api/demo/DemoActivitySingleTop.java
@@ -45,7 +45,7 @@ public class DemoActivitySingleTop extends AppCompatActivity {
 
         BrowserSwitchPendingRequest.Started pendingRequest = PendingRequestStore.Companion.get(this);
         if (pendingRequest != null) {
-            BrowserSwitchResult result = browserSwitchClient.parseResult(pendingRequest, intent);
+            BrowserSwitchResult result = browserSwitchClient.completeRequest(pendingRequest, intent);
             if (result instanceof BrowserSwitchResult.Success) {
                 Objects.requireNonNull(getDemoFragment()).onBrowserSwitchResult(((BrowserSwitchResult.Success) result).getResultInfo());
             }

--- a/v3_MIGRATION_GUIDE.md
+++ b/v3_MIGRATION_GUIDE.md
@@ -67,7 +67,7 @@ class MyActivity : ComponentActivity() {
     fun handleReturnToAppFromBrowser(intent: Intent) {
         // fetch stored pending request
         fetchPendingRequestFromPersistentStorage()?.let { startedRequest ->
-            when (val browserSwitchResult = browserSwitchClient.parseResult(startedRequest, intent)) {
+            when (val browserSwitchResult = browserSwitchClient.completeRequest(startedRequest, intent)) {
                 is BrowserSwitchResult.Success -> {
                     // handle successful browser switch result
                     // clear stored pending request


### PR DESCRIPTION
### Summary of changes

 - Rename `parseResult()` to `completeRequest()`

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
