### PR TITLE
[V3] Rename BrowserSwitchStartResult `.Success` to `.Started`

### DIFF
--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -42,7 +42,7 @@ public class BrowserSwitchClient {
      *
      * @param activity             the activity used to start browser switch
      * @param browserSwitchOptions {@link BrowserSwitchOptions} the options used to configure the browser switch
-     * @return a {@link BrowserSwitchStartResult.Success} that should be stored and passed to
+     * @return a {@link BrowserSwitchStartResult.Started} that should be stored and passed to
      * {@link BrowserSwitchClient#completeRequest(Intent, String)} upon return to the app,
      * or {@link BrowserSwitchStartResult.Failure} if browser could not be launched.
      */
@@ -77,7 +77,7 @@ public class BrowserSwitchClient {
                         appLinkUri
                 );
                 customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
-                return new BrowserSwitchStartResult.Success(request.toBase64EncodedJSON());
+                return new BrowserSwitchStartResult.Started(request.toBase64EncodedJSON());
             } catch (ActivityNotFoundException | BrowserSwitchException e) {
                 return new BrowserSwitchStartResult.Failure(new BrowserSwitchException("Unable to start browser switch without a web browser.", e));
             }
@@ -126,7 +126,7 @@ public class BrowserSwitchClient {
      *
      * @param intent         the intent to return to your application containing a deep link result from the
      *                       browser flow
-     * @param pendingRequest the pending request string returned from {@link BrowserSwitchStartResult.Success} via
+     * @param pendingRequest the pending request string returned from {@link BrowserSwitchStartResult.Started} via
      *                       {@link BrowserSwitchClient#start(ComponentActivity, BrowserSwitchOptions)}
      * @return a {@link BrowserSwitchFinalResult.Success} if the browser switch was successfully
      * completed, or {@link BrowserSwitchFinalResult.NoResult} if no result can be found for the given

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchStartResult.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchStartResult.kt
@@ -9,7 +9,7 @@ sealed class BrowserSwitchStartResult {
      * The browser switch was successfully completed. Store pendingRequest String to complete
      * browser switch after deeplinking back into the application (see [BrowserSwitchClient.completeRequest]).
      */
-    class Success(val pendingRequest: String) : BrowserSwitchStartResult()
+    class Started(val pendingRequest: String) : BrowserSwitchStartResult()
 
     /**
      * Browser switch failed with an [error].

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -94,10 +94,10 @@ public class BrowserSwitchClientUnitTest {
         verify(customTabsInternalClient).launchUrl(componentActivity, browserSwitchDestinationUrl, false);
 
         assertNotNull(browserSwitchPendingRequest);
-        assertTrue(browserSwitchPendingRequest instanceof BrowserSwitchStartResult.Success);
+        assertTrue(browserSwitchPendingRequest instanceof BrowserSwitchStartResult.Started);
 
         String pendingRequest =
-                ((BrowserSwitchStartResult.Success) browserSwitchPendingRequest).getPendingRequest();
+                ((BrowserSwitchStartResult.Started) browserSwitchPendingRequest).getPendingRequest();
         BrowserSwitchRequest browserSwitchRequest =
                 BrowserSwitchRequest.fromBase64EncodedJSON(pendingRequest);
 

--- a/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/ComposeActivity.kt
+++ b/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/ComposeActivity.kt
@@ -71,7 +71,7 @@ class ComposeActivity : ComponentActivity() {
             .launchAsNewTask(false)
             .returnUrlScheme(RETURN_URL_SCHEME)
         when (val startResult = browserSwitchClient.start(this, browserSwitchOptions)) {
-            is BrowserSwitchStartResult.Success ->
+            is BrowserSwitchStartResult.Started ->
                 PendingRequestStore.put(this, startResult.pendingRequest)
 
             is BrowserSwitchStartResult.Failure -> viewModel.browserSwitchError = startResult.error

--- a/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/DemoActivitySingleTop.java
+++ b/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/DemoActivitySingleTop.java
@@ -43,13 +43,13 @@ public class DemoActivitySingleTop extends AppCompatActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
-        String pendingRequest = PendingRequestStore.Companion.get(this);
+        String pendingRequest = PendingRequestStore.get(this);
         if (pendingRequest != null) {
             BrowserSwitchFinalResult result = browserSwitchClient.completeRequest(intent, pendingRequest);
             if (result instanceof BrowserSwitchFinalResult.Success) {
                 Objects.requireNonNull(getDemoFragment()).onBrowserSwitchResult((BrowserSwitchFinalResult.Success) result);
             }
-            PendingRequestStore.Companion.clear(this);
+            PendingRequestStore.clear(this);
         }
     }
 
@@ -57,17 +57,17 @@ public class DemoActivitySingleTop extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        String pendingRequest = PendingRequestStore.Companion.get(this);
+        String pendingRequest = PendingRequestStore.get(this);
         if (pendingRequest != null) {
             Objects.requireNonNull(getDemoFragment()).onBrowserSwitchError(new Exception("User did not complete browser switch"));
-            PendingRequestStore.Companion.clear(this);
+            PendingRequestStore.clear(this);
         }
     }
 
     public void startBrowserSwitch(BrowserSwitchOptions options) throws BrowserSwitchException {
         BrowserSwitchStartResult result = browserSwitchClient.start(this, options);
         if (result instanceof BrowserSwitchStartResult.Started) {
-            PendingRequestStore.Companion.put(this, ((BrowserSwitchStartResult.Started) result).getPendingRequest());
+            PendingRequestStore.put(this, ((BrowserSwitchStartResult.Started) result).getPendingRequest());
         } else if (result instanceof BrowserSwitchStartResult.Failure) {
             Objects.requireNonNull(getDemoFragment()).onBrowserSwitchError(((BrowserSwitchStartResult.Failure) result).getError());
         }

--- a/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/DemoActivitySingleTop.java
+++ b/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/DemoActivitySingleTop.java
@@ -66,8 +66,8 @@ public class DemoActivitySingleTop extends AppCompatActivity {
 
     public void startBrowserSwitch(BrowserSwitchOptions options) throws BrowserSwitchException {
         BrowserSwitchStartResult result = browserSwitchClient.start(this, options);
-        if (result instanceof BrowserSwitchStartResult.Success) {
-            PendingRequestStore.Companion.put(this, ((BrowserSwitchStartResult.Success) result).getPendingRequest());
+        if (result instanceof BrowserSwitchStartResult.Started) {
+            PendingRequestStore.Companion.put(this, ((BrowserSwitchStartResult.Started) result).getPendingRequest());
         } else if (result instanceof BrowserSwitchStartResult.Failure) {
             Objects.requireNonNull(getDemoFragment()).onBrowserSwitchError(((BrowserSwitchStartResult.Failure) result).getError());
         }

--- a/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/utils/PendingRequestStore.kt
+++ b/demo/src/main/java/com/braintreepayments/api/browserswitch/demo/utils/PendingRequestStore.kt
@@ -10,6 +10,7 @@ class PendingRequestStore {
         private const val SHARED_PREFS_KEY = "PENDING_REQUESTS"
         private const val PENDING_REQUEST_KEY = "BROWSER_SWITCH_REQUEST"
 
+        @JvmStatic
         fun put(context: Context, pendingRequest: String) {
             val sharedPreferences: SharedPreferences = context.getSharedPreferences(
                 SHARED_PREFS_KEY,
@@ -18,6 +19,7 @@ class PendingRequestStore {
             sharedPreferences.edit().putString(PENDING_REQUEST_KEY, pendingRequest).apply()
         }
 
+        @JvmStatic
         fun get(context: Context): String? {
             val sharedPreferences: SharedPreferences = context.getSharedPreferences(
                 SHARED_PREFS_KEY,
@@ -26,6 +28,7 @@ class PendingRequestStore {
             return sharedPreferences.getString(PENDING_REQUEST_KEY, null)
         }
 
+        @JvmStatic
         fun clear(context: Context) {
             val sharedPreferences: SharedPreferences = context.getSharedPreferences(
                 SHARED_PREFS_KEY,


### PR DESCRIPTION
### Summary of changes

- Rename `BrowserSwitchStartResult.Success` to `BrowserSwitchStartResult.Started`

 ### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire
