### PR TITLE
Fix v3 migration guide file name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ task changeREADMEVersion {
 
 task changeMigrationGuideVersion {
     doLast {
-        def migrationGuideFile = new File('v3_MIGRATION.md')
+        def migrationGuideFile = new File('v3_MIGRATION_GUIDE.md')
         def migrationGuideFileText = migrationGuideFile.text.replaceAll(":\\d+\\.\\d+\\.\\d+(-.*)?'", ":" + versionParam + "'")
         migrationGuideFile.write(migrationGuideFileText)
     }


### PR DESCRIPTION
### Summary of changes

 - Fix v3 migration guide file name in changeMigrationGuideVersion gradle task

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
