### PR TITLE
Add Temp Post Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       job_to_run:
         description: 'Run individual job (DO NOT USE THIS FOR A NORMAL RELEASE)'
         required: false
+        type: choice
         options:
           - bump_version
           - create_github_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,6 @@ on:
       version:
         description: 'Version to release'
         required: true
-      job_to_run:
-        description: 'Run individual job (DO NOT USE THIS FOR A NORMAL RELEASE)'
-        required: false
-        type: choice
-        options:
-          - bump_version
-          - create_github_release
 env:
   SIGNING_KEY_FILE: /home/runner/secretKey.gpg
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
       version:
         description: 'Version to release'
         required: true
+      job_to_run:
+        description: 'Run individual job (DO NOT USE THIS FOR A NORMAL RELEASE)'
+        required: false
+        options:
+          - bump_version
+          - create_github_release
 env:
   SIGNING_KEY_FILE: /home/runner/secretKey.gpg
 jobs:

--- a/.github/workflows/temp_post_release.yml
+++ b/.github/workflows/temp_post_release.yml
@@ -1,0 +1,53 @@
+name: Temp Post Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+env:
+  SIGNING_KEY_FILE: /home/runner/secretKey.gpg
+jobs:
+  bump_version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
+      - name: Set GitHub User
+        run: ./ci set_github_user_to_braintreeps
+      - name: Update Version
+        run: |
+          ./ci publish_dokka_docs
+          ./ci update_version ${{ github.event.inputs.version }}
+          ./ci commit_and_tag_release ${{ github.event.inputs.version }}
+          ./ci increment_snapshot_version ${{ github.event.inputs.version }}
+          ./ci increment_demo_app_version_code
+
+          git commit -am 'Prepare for development'
+          git push origin main ${{ github.event.inputs.version }}
+
+  create_github_release:
+    needs: [ bump_version ]
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: ./.github/actions/setup_java
+      - name: Save changelog entries to a file
+        run: ./ci get_latest_changelog_entries > changelog_entries.md
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body_path: changelog_entries.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Thank you for your contribution to Braintree. 


### Summary of changes

 - Add a temporary workflow to run the `bump_version` and `create_github_release` jobs which were not run for the 3.0.0-beta1 release

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
