### PR TITLE
Downgrade to Support Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## unreleased
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 35
-* Breaking Changes
-  * Bump target Java version to Java 17
 
 ## 3.0.0-beta1
 

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -30,7 +30,6 @@ android {
         }
     }
 
-
     // robolectric
     testOptions {
         unitTests {

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -20,6 +20,17 @@ android {
         targetCompatibility versions.javaTargetCompatibility
     }
 
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    kotlin {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of("11"))
+        }
+    }
+
+
     // robolectric
     testOptions {
         unitTests {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
 
-    def sdkTargetJavaVersion = JavaVersion.VERSION_17
+    def sdkTargetJavaVersion = JavaVersion.VERSION_11
     ext.versions = [
         "javaSourceCompatibility": sdkTargetJavaVersion,
         "javaTargetCompatibility": sdkTargetJavaVersion,

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -35,12 +35,6 @@ android {
         jvmTarget = "11"
     }
 
-    kotlin {
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of("11"))
-        }
-    }
-
     buildFeatures {
         compose true
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -30,6 +30,17 @@ android {
         sourceCompatibility versions.javaSourceCompatibility
         targetCompatibility versions.javaTargetCompatibility
     }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
+    kotlin {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of("11"))
+        }
+    }
+
     buildFeatures {
         compose true
     }


### PR DESCRIPTION
### Summary of changes

 - Revert changes that require Java 17 in this SDK to allow merchants using Java 11 to integrate
 - Keep Java 17 usage for CI and internal build tools, but update to compile SDK for Java 11 (see [Android docs](https://developer.android.com/build/jdks) for additional info on Java usage in Android)
 - This change will be followed by similar change in the core SDK to support Java 11

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @sarahkoop 
