### PR TITLE
Add ability to set Intent.FLAG_ACTIVITY_CLEAR_TOP on the CustomTabsIntent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # browser-switch-android Release Notes
 
+## unreleased
+
+* Add `LaunchType` to `BrowserSwitchOptions` to specify how the browser switch should be launched
+  * Add ability to set `Intent.FLAG_ACTIVITY_CLEAR_TOP` on the `CustomTabsIntent`
+* Deprecate `launchAsNewTask` in `BrowserSwitchOptions` in favor of `LaunchType`
+
 ## 3.0.0
 
 * Upgrade `compileSdkVersion` and `targetSdkVersion` to API 35

--- a/browser-switch/build.gradle
+++ b/browser-switch/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation deps.mockitoCore
     testImplementation deps.jsonassert
     testImplementation deps.robolectric
+    testImplementation deps.mockk
 }
 
 // region signing and publishing
@@ -60,4 +61,3 @@ project.ext.pom_desc = "Android Browser Switch makes it easy to open a url in a 
 apply from: rootProject.file("gradle/gradle-publish.gradle")
 
 // endregion
-

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchClient.java
@@ -66,7 +66,7 @@ public class BrowserSwitchClient {
                     "Unable to start browser switch while host Activity is finishing.";
             return new BrowserSwitchStartResult.Failure(new BrowserSwitchException(activityFinishingMessage));
         } else {
-            boolean launchAsNewTask = browserSwitchOptions.isLaunchAsNewTask();
+            LaunchType launchType = browserSwitchOptions.getLaunchType();
             BrowserSwitchRequest request;
             try {
                 request = new BrowserSwitchRequest(
@@ -76,7 +76,7 @@ public class BrowserSwitchClient {
                         returnUrlScheme,
                         appLinkUri
                 );
-                customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchAsNewTask);
+                customTabsInternalClient.launchUrl(activity, browserSwitchUrl, launchType);
                 return new BrowserSwitchStartResult.Started(request.toBase64EncodedJSON());
             } catch (ActivityNotFoundException | BrowserSwitchException e) {
                 return new BrowserSwitchStartResult.Failure(new BrowserSwitchException("Unable to start browser switch without a web browser.", e));

--- a/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/BrowserSwitchOptions.java
@@ -19,6 +19,7 @@ public class BrowserSwitchOptions {
     private Uri appLinkUri;
 
     private boolean launchAsNewTask;
+    private LaunchType launchType;
 
     /**
      * Set browser switch metadata.
@@ -117,12 +118,39 @@ public class BrowserSwitchOptions {
         return appLinkUri;
     }
 
+    /**
+     * @deprecated Use {@link #getLaunchType()} instead.
+     */
+    @Deprecated
     public boolean isLaunchAsNewTask() {
         return launchAsNewTask;
     }
 
+    /**
+     * @deprecated Use {@link #launchType(LaunchType)} instead.
+     */
+    @Deprecated
     public BrowserSwitchOptions launchAsNewTask(boolean launchAsNewTask) {
         this.launchAsNewTask = launchAsNewTask;
+        this.launchType = LaunchType.ACTIVITY_NEW_TASK;
+        return this;
+    }
+
+    /**
+     * @return the activity launch type flag.
+     */
+    public LaunchType getLaunchType() {
+        return launchType;
+    }
+
+    /**
+     * Sets the activity launch type flag.
+     *
+     * @param launchType the type of launch for the browser activity
+     * @return {@link BrowserSwitchOptions} reference to instance to allow setter invocations to be chained
+     */
+    public BrowserSwitchOptions launchType(LaunchType launchType) {
+        this.launchType = launchType;
         return this;
     }
 }

--- a/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
@@ -21,10 +21,15 @@ class ChromeCustomTabsInternalClient {
         this.customTabsIntentBuilder = builder;
     }
 
-    void launchUrl(Context context, Uri url, boolean launchAsNewTask) throws ActivityNotFoundException{
+    void launchUrl(Context context, Uri url, LaunchType launchType) throws ActivityNotFoundException {
         CustomTabsIntent customTabsIntent = customTabsIntentBuilder.build();
-        if (launchAsNewTask) {
-            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        switch (launchType) {
+            case ACTIVITY_NEW_TASK:
+                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                break;
+            case ACTIVITY_CLEAR_TOP:
+                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                break;
         }
         customTabsIntent.launchUrl(context, url);
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
+++ b/browser-switch/src/main/java/com/braintreepayments/api/ChromeCustomTabsInternalClient.java
@@ -23,13 +23,15 @@ class ChromeCustomTabsInternalClient {
 
     void launchUrl(Context context, Uri url, LaunchType launchType) throws ActivityNotFoundException {
         CustomTabsIntent customTabsIntent = customTabsIntentBuilder.build();
-        switch (launchType) {
-            case ACTIVITY_NEW_TASK:
-                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                break;
-            case ACTIVITY_CLEAR_TOP:
-                customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                break;
+        if (launchType != null) {
+            switch (launchType) {
+                case ACTIVITY_NEW_TASK:
+                    customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    break;
+                case ACTIVITY_CLEAR_TOP:
+                    customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                    break;
+            }
         }
         customTabsIntent.launchUrl(context, url);
     }

--- a/browser-switch/src/main/java/com/braintreepayments/api/LaunchType.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/LaunchType.kt
@@ -1,0 +1,6 @@
+package com.braintreepayments.api
+
+enum class LaunchType {
+    ACTIVITY_NEW_TASK,
+    ACTIVITY_CLEAR_TOP
+}

--- a/browser-switch/src/main/java/com/braintreepayments/api/LaunchType.kt
+++ b/browser-switch/src/main/java/com/braintreepayments/api/LaunchType.kt
@@ -1,5 +1,11 @@
 package com.braintreepayments.api
 
+/**
+ * Enum representing the type of launch for an activity.
+ *
+ * - [ACTIVITY_NEW_TASK]: sets the `Intent.FLAG_ACTIVITY_NEW_TASK` flag.
+ * - [ACTIVITY_CLEAR_TOP]: sets the `Intent.FLAG_ACTIVITY_CLEAR_TOP` flag.
+ */
 enum class LaunchType {
     ACTIVITY_NEW_TASK,
     ACTIVITY_CLEAR_TOP

--- a/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
+++ b/browser-switch/src/test/java/com/braintreepayments/api/BrowserSwitchClientUnitTest.java
@@ -37,7 +37,6 @@ public class BrowserSwitchClientUnitTest {
     private ChromeCustomTabsInternalClient customTabsInternalClient;
 
     private Uri browserSwitchDestinationUrl;
-    private Uri appLinkUri;
     private Context applicationContext;
 
     private ComponentActivity componentActivity;
@@ -48,7 +47,6 @@ public class BrowserSwitchClientUnitTest {
         customTabsInternalClient = mock(ChromeCustomTabsInternalClient.class);
 
         browserSwitchDestinationUrl = Uri.parse("https://example.com/browser_switch_destination");
-        appLinkUri = Uri.parse("https://example.com");
 
         ActivityController<ComponentActivity> componentActivityController =
                 Robolectric.buildActivity(ComponentActivity.class).setup();
@@ -90,10 +88,11 @@ public class BrowserSwitchClientUnitTest {
                 .requestCode(123)
                 .url(browserSwitchDestinationUrl)
                 .returnUrlScheme("return-url-scheme")
+                .launchType(LaunchType.ACTIVITY_CLEAR_TOP)
                 .metadata(metadata);
         BrowserSwitchStartResult browserSwitchPendingRequest = sut.start(componentActivity, options);
 
-        verify(customTabsInternalClient).launchUrl(componentActivity, browserSwitchDestinationUrl, false);
+        verify(customTabsInternalClient).launchUrl(componentActivity, browserSwitchDestinationUrl, LaunchType.ACTIVITY_CLEAR_TOP);
 
         assertNotNull(browserSwitchPendingRequest);
         assertTrue(browserSwitchPendingRequest instanceof BrowserSwitchStartResult.Started);
@@ -111,7 +110,7 @@ public class BrowserSwitchClientUnitTest {
     @Test
     public void start_whenNoBrowserAvailable_returnsFailure() {
         when(browserSwitchInspector.isDeviceConfiguredForDeepLinking(applicationContext, "return-url-scheme")).thenReturn(true);
-        doThrow(new ActivityNotFoundException()).when(customTabsInternalClient).launchUrl(any(Context.class), any(Uri.class), eq(false));
+        doThrow(new ActivityNotFoundException()).when(customTabsInternalClient).launchUrl(any(Context.class), any(Uri.class), eq(null));
 
         BrowserSwitchClient sut = new BrowserSwitchClient(browserSwitchInspector,
                 customTabsInternalClient);

--- a/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.kt
+++ b/browser-switch/src/test/java/com/braintreepayments/api/ChromeCustomTabsInternalClientUnitTest.kt
@@ -1,0 +1,64 @@
+package com.braintreepayments.api
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ChromeCustomTabsInternalClientUnitTest {
+
+    private lateinit var builder: CustomTabsIntent.Builder
+    private lateinit var customTabsIntent: CustomTabsIntent
+    private lateinit var context: Context
+    private lateinit var url: Uri
+
+    @Before
+    fun setUp() {
+        clearAllMocks()
+        builder = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+        url = mockk(relaxed = true)
+        customTabsIntent = CustomTabsIntent.Builder().build()
+        every { builder.build() } returns customTabsIntent
+    }
+
+    @Test
+    fun `launchUrl with null LaunchType does not add flags`() {
+        val client = ChromeCustomTabsInternalClient(builder)
+        val intent = customTabsIntent.intent
+
+        client.launchUrl(context, url, null)
+
+        assertEquals(0, intent.flags)
+    }
+
+    @Test
+    fun `launchUrl with ACTIVITY_NEW_TASK adds new task flag`() {
+        val client = ChromeCustomTabsInternalClient(builder)
+        val intent = customTabsIntent.intent
+
+        client.launchUrl(context, url, LaunchType.ACTIVITY_NEW_TASK)
+
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun `launchUrl with ACTIVITY_CLEAR_TOP adds clear top flag`() {
+        val client = ChromeCustomTabsInternalClient(builder)
+        val intent = customTabsIntent.intent
+
+        client.launchUrl(context, url, LaunchType.ACTIVITY_CLEAR_TOP)
+
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TOP != 0)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ buildscript {
         'junit'       : 'junit:junit:4.13.2',
         'mockitoCore' : 'org.mockito:mockito-core:5.7.0',
         'jsonassert'  : 'org.skyscreamer:jsonassert:1.5.1',
-        'robolectric' : 'org.robolectric:robolectric:4.11.1'
+        'robolectric' : 'org.robolectric:robolectric:4.11.1',
+        'mockk'       : 'io.mockk:mockk:1.13.10'
     ]
 
     dependencies {


### PR DESCRIPTION
### Summary of changes

 - Create new `LaunchType` enum that sets either `Intent.FLAG_ACTIVITY_NEW_TASK` or `Intent.FLAG_ACTIVITY_CLEAR_TOP` on the `CustomTabsIntent`
 - Updated `BrowserSwitchOptions` builder to accept `LaunchType`
 - Deprecated `launchAsNewTask` boolean in `BrowserSwitchOptions`
 - Added mockk dependency

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 
